### PR TITLE
feat: add Reddit Ads full conversion tracking (Pixel v2 + CAPI)

### DIFF
--- a/app/api/reddit-capi/route.ts
+++ b/app/api/reddit-capi/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { sendRedditCAPIEvent, RedditCAPIEventParams } from '@/lib/redditCAPI';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function POST(req: NextRequest) {
+  let body: Partial<RedditCAPIEventParams> & { email?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'invalid json' }, { status: 400 });
+  }
+
+  const { eventType, clickId, email, userAgent, orderId, value, currency } = body;
+
+  if (!eventType) {
+    return NextResponse.json({ error: 'eventType is required' }, { status: 400 });
+  }
+
+  const ip =
+    req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+    req.headers.get('x-real-ip') ||
+    null;
+
+  try {
+    await sendRedditCAPIEvent({
+      eventType,
+      clickId: clickId ?? null,
+      email: email ?? null,
+      ipAddress: ip,
+      userAgent: userAgent ?? req.headers.get('user-agent') ?? null,
+      orderId: orderId ?? null,
+      value,
+      currency,
+    });
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    console.error('[Reddit CAPI route] failed:', err);
+    return NextResponse.json({ error: 'capi_failed' }, { status: 502 });
+  }
+}

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import crypto from 'crypto';
+import { sendRedditCAPIEvent } from '@/lib/redditCAPI';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -106,6 +107,19 @@ async function handleCheckoutSession(obj: any): Promise<void> {
   fields.push({ name: 'Source', value: obj.payment_link ? `Payment Link (${obj.payment_link})` : 'Checkout', inline: true });
   fields.push({ name: 'Session', value: obj.id, inline: true });
   fields.push(...metadataFields(obj.metadata));
+
+  // Reddit CAPI — Purchase event (server-side, deduplicated via session ID)
+  try {
+    await sendRedditCAPIEvent({
+      eventType: 'Purchase',
+      email: email !== 'unknown' ? email : null,
+      orderId: obj.id, // Stripe session ID as deduplication key
+      value: obj.amount_total != null ? obj.amount_total / 100 : undefined,
+      currency: obj.currency?.toUpperCase() || 'USD',
+    });
+  } catch (err) {
+    console.error('[Reddit CAPI] Purchase event failed (non-fatal):', err);
+  }
 
   await postDiscord(`✅ **New Payment** — ${amount}`, [
     {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -237,12 +237,12 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             alt=""
           />
         </noscript>
-        {/* Reddit Pixel — loaded after page paint, non-blocking */}
+        {/* Reddit Pixel v2 — loaded after page paint, non-blocking */}
         <Script
           id="reddit-pixel"
           strategy="afterInteractive"
           dangerouslySetInnerHTML={{
-            __html: `!function(w,d){if(!w.rdt){var p=w.rdt=function(){p.sendEvent?p.sendEvent.apply(p,arguments):p.callQueue.push(arguments)};p.callQueue=[];var t=d.createElement("script");t.src="https://www.redditstatic.com/ads/pixel.js?pixel_id=a2_j7kj6g9uvz00",t.async=!0;var s=d.getElementsByTagName("script")[0];s.parentNode.insertBefore(t,s)}}(window,document);rdt('init','a2_j7kj6g9uvz00');rdt('track','PageVisit');`
+            __html: `!function(w,d){if(!w.rdt){var p=w.rdt=function(){p.sendEvent?p.sendEvent.apply(p,arguments):p.callQueue.push(arguments)};p.callQueue=[];var t=d.createElement("script");t.src="https://www.redditstatic.com/ads/v2/rdtag.js";t.async=!0;var s=d.getElementsByTagName("script")[0];s.parentNode.insertBefore(t,s)}}(window,document);rdt('init','a2_j8tdb9hlk690');rdt('track','PageVisit');`
           }}
         />
         {/* LinkedIn Insight Tag - Load with afterInteractive strategy */}

--- a/lib/redditCAPI.ts
+++ b/lib/redditCAPI.ts
@@ -1,0 +1,69 @@
+import crypto from 'crypto';
+
+const PIXEL_ID = process.env.REDDIT_PIXEL_ID || 'a2_j8tdb9hlk690';
+const CAPI_TOKEN = process.env.REDDIT_CAPI_TOKEN || '';
+
+export function hashEmail(email: string | null | undefined): string | null {
+  if (!email) return null;
+  return crypto.createHash('sha256').update(email.trim().toLowerCase()).digest('hex');
+}
+
+export interface RedditCAPIEventParams {
+  eventType: 'Purchase' | 'Lead' | 'SignUp' | 'AddToCart' | 'ViewContent' | 'PageVisit';
+  clickId?: string | null;
+  email?: string | null;
+  ipAddress?: string | null;
+  userAgent?: string | null;
+  orderId?: string | null;
+  value?: number;
+  currency?: string;
+}
+
+export async function sendRedditCAPIEvent(params: RedditCAPIEventParams): Promise<void> {
+  if (!CAPI_TOKEN) {
+    console.warn('[Reddit CAPI] REDDIT_CAPI_TOKEN not set — skipping');
+    return;
+  }
+
+  const { eventType, clickId, email, ipAddress, userAgent, orderId, value, currency = 'USD' } = params;
+
+  const payload = {
+    test_mode: false,
+    events: [
+      {
+        event_at: new Date().toISOString(),
+        event_type: { tracking_type: eventType },
+        ...(clickId ? { click_id: clickId } : {}),
+        user: {
+          ...(email ? { email: hashEmail(email) } : {}),
+          ...(ipAddress ? { ip_address: ipAddress } : {}),
+          ...(userAgent ? { user_agent: userAgent } : {}),
+        },
+        custom_event_source: 'SERVER',
+        ...(orderId ? { order_id: orderId } : {}),
+        ...(value !== undefined ? { value, currency } : {}),
+      },
+    ],
+  };
+
+  const response = await fetch(
+    `https://ads-api.reddit.com/api/v2.0/conversions/events/${PIXEL_ID}`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${CAPI_TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    }
+  );
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    console.error('[Reddit CAPI] Error:', response.status, errorText);
+    throw new Error(`Reddit CAPI failed: ${response.status}`);
+  }
+
+  const result = await response.json();
+  console.log('[Reddit CAPI] Success:', result);
+}

--- a/src/components/calendlyModal/CalendlyModal.tsx
+++ b/src/components/calendlyModal/CalendlyModal.tsx
@@ -160,9 +160,29 @@ export default function CalendlyModal({
           }
         } catch {}
 
-        // Reddit Pixel - Lead event on meeting booked
-        if (typeof window !== "undefined" && (window as any).rdt) {
-          (window as any).rdt('track', 'Lead');
+        // Reddit Pixel - Lead event on meeting booked with deduplication transactionId
+        const rdtLeadEventId = typeof crypto !== "undefined" && crypto.randomUUID
+          ? crypto.randomUUID()
+          : `lead-${Date.now()}`;
+        if (typeof window !== "undefined") {
+          if ((window as any).rdt) {
+            (window as any).rdt('track', 'Lead', { transactionId: rdtLeadEventId });
+            console.log('[Reddit Pixel] Lead fired, transactionId:', rdtLeadEventId);
+          }
+          // Read rdt_cid cookie and send CAPI Lead event server-side for deduplication
+          const rdtCidMatch = document.cookie.match(/(^| )rdt_cid=([^;]+)/);
+          const rdtClickId = rdtCidMatch ? decodeURIComponent(rdtCidMatch[2]) : null;
+          fetch('/api/reddit-capi', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              eventType: 'Lead',
+              clickId: rdtClickId,
+              email: inviteeEmail,
+              userAgent: navigator.userAgent,
+              orderId: rdtLeadEventId,
+            }),
+          }).catch((err) => console.error('[Reddit CAPI] Lead call failed:', err));
         }
 
         // Navigate to meeting-booked page

--- a/src/components/signupModal/SignupModal.tsx
+++ b/src/components/signupModal/SignupModal.tsx
@@ -159,9 +159,29 @@ export default function SignupModal({ isOpen, onClose }: SignupModalProps) {
       country_code: formData.countryCode
     });
 
-    // Reddit Pixel - Lead event on signup form submit
-    if (typeof window !== "undefined" && (window as any).rdt) {
-      (window as any).rdt('track', 'Lead');
+    // Reddit Pixel - SignUp event with deduplication transactionId
+    const rdtSignupEventId = typeof crypto !== "undefined" && crypto.randomUUID
+      ? crypto.randomUUID()
+      : `signup-${Date.now()}`;
+    if (typeof window !== "undefined") {
+      if ((window as any).rdt) {
+        (window as any).rdt('track', 'SignUp', { transactionId: rdtSignupEventId });
+        console.log('[Reddit Pixel] SignUp fired, transactionId:', rdtSignupEventId);
+      }
+      // Read rdt_cid cookie and send CAPI Lead event server-side for deduplication
+      const rdtCidMatch = document.cookie.match(/(^| )rdt_cid=([^;]+)/);
+      const rdtClickId = rdtCidMatch ? decodeURIComponent(rdtCidMatch[2]) : null;
+      fetch('/api/reddit-capi', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          eventType: 'SignUp',
+          clickId: rdtClickId,
+          email: formData.email,
+          userAgent: navigator.userAgent,
+          orderId: rdtSignupEventId,
+        }),
+      }).catch((err) => console.error('[Reddit CAPI] SignUp call failed:', err));
     }
 
     // Open Calendly modal IMMEDIATELY (don't wait for backend)


### PR DESCRIPTION
- Update pixel to new ID a2_j8tdb9hlk690 and v2 rdtag.js URL in layout.tsx
- Add lib/redditCAPI.ts: server-side SHA-256 email hashing + sendRedditCAPIEvent()
- Add app/api/reddit-capi/route.ts: Next.js API route that proxies CAPI calls (token never exposed to browser)
- SignupModal: fire rdt('track','SignUp',{transactionId}) + read rdt_cid cookie + call CAPI /api/reddit-capi
- CalendlyModal: fire rdt('track','Lead',{transactionId}) + read rdt_cid cookie + call CAPI /api/reddit-capi
- Stripe webhook: fire Reddit CAPI Purchase on checkout.session.completed with session ID as dedup key