### PR TITLE
seo: trim page titles, add FAQ + pricing schemas, remove inflated rev…

### DIFF
--- a/app/en-ca/AI-copilot/page.tsx
+++ b/app/en-ca/AI-copilot/page.tsx
@@ -3,7 +3,7 @@ import AICopilot from "@/src/components/AICopilot/AICopilot";
 import Footer from "@/src/components/footer/footer";
 import Navbar from "@/src/components/navbar/navbar";
 const metadata: Metadata = {
-  title: "AI Copilot - Get personalized interview tips | Flashfire",
+  title: "AI Copilot: Personalized Interview Tips | Flashfire",
   description:
     "Get personalized interview tips based on your skills, experience, and career goals. Our interview buddy is here to help you land your dream job.",
   robots: {
@@ -14,7 +14,7 @@ const metadata: Metadata = {
     canonical: "https://www.flashfirejobs.com/en-ca/AI-copilot",
   },
   openGraph: {
-    title: "AI Copilot - Get personalized interview tips",
+    title: "AI Copilot: Personalized Interview Tips | Flashfire",
     description:
       "Get personalized interview tips based on your skills, experience, and career goals.",
     url: "https://www.flashfirejobs.com/en-ca/AI-copilot",

--- a/app/en-ca/blog/page.tsx
+++ b/app/en-ca/blog/page.tsx
@@ -5,7 +5,7 @@ import Footer from "@/src/components/footer/footer";
 import Navbar from "@/src/components/navbar/navbar";
 
 export const metadata: Metadata = {
-  title: "Blog - Career Tips, Job Search Advice & Industry Insights | Flashfire (Canada)",
+  title: "Flashfire Blog: Canadian Career Tips & Job Advice",
   description:
     "Discover expert career tips, job search strategies, resume writing guides, and industry insights to accelerate your job search success.",
   robots: {
@@ -16,7 +16,7 @@ export const metadata: Metadata = {
     canonical: "https://www.flashfirejobs.com/en-ca/blog",
   },
   openGraph: {
-    title: "Blog - Career Tips & Job Search Advice",
+    title: "Flashfire Blog: Canadian Career Tips & Job Advice",
     description:
       "Discover expert career tips, job search strategies, and industry insights.",
     url: "https://www.flashfirejobs.com/en-ca/blog",

--- a/app/en-ca/blogs/page.tsx
+++ b/app/en-ca/blogs/page.tsx
@@ -9,7 +9,7 @@ export const dynamic = 'force-static';
 export const revalidate = false;
 
 export const metadata: Metadata = {
-  title: "Blog - Career Tips, Job Search Advice & Industry Insights | Flashfire (Canada)",
+  title: "Flashfire Blog: Canadian Career Tips & Job Advice",
   description:
     "Discover expert career tips, job search strategies, resume writing guides, and industry insights to accelerate your job search success.",
   robots: {
@@ -20,7 +20,7 @@ export const metadata: Metadata = {
     canonical: "https://www.flashfirejobs.com/en-ca/blogs",
   },
   openGraph: {
-    title: "Blog - Career Tips & Job Search Advice",
+    title: "Flashfire Blog: Canadian Career Tips & Job Advice",
     description:
       "Discover expert career tips, job search strategies, and industry insights.",
     url: "https://www.flashfirejobs.com/en-ca/blogs",

--- a/app/en-ca/career-advisor/page.tsx
+++ b/app/en-ca/career-advisor/page.tsx
@@ -3,7 +3,7 @@ import CareerAdvisor from "@/src/components/careerAdvisor/careerAdvisor";
 import Footer from "@/src/components/footer/footer";
 import Navbar from "@/src/components/navbar/navbar";
 export const metadata: Metadata = {
-    title: "Career Advisor - Get personalized job recommendations | Flashfire",
+    title: "AI Career Advisor: Personalized Job Recommendations",
     description:
         "Get personalized job recommendations based on your skills, experience, and career goals. Our career advisor is here to help you find the perfect job.",
     robots: {
@@ -14,7 +14,7 @@ export const metadata: Metadata = {
         canonical: "https://www.flashfirejobs.com/en-ca/career-advisor",
     },
     openGraph: {
-        title: "Career Advisor - Get personalized job recommendations",
+        title: "AI Career Advisor: Personalized Job Recommendations",
         description:
             "Get personalized job recommendations based on your skills, experience, and career goals.",
         url: "https://www.flashfirejobs.com/career-advisor",

--- a/app/en-ca/contact-us/page.tsx
+++ b/app/en-ca/contact-us/page.tsx
@@ -4,7 +4,7 @@ import Footer from "@/src/components/footer/footer";
 import Navbar from "@/src/components/navbar/navbar";
 
 export const metadata: Metadata = {
-  title: "Contact Us - Get in Touch with Flashfire | Flashfire Canada",
+  title: "Contact Flashfire: Get in Touch | Flashfire Canada",
   description:
     "Have questions about Flashfire? Contact our Canada team for support, partnerships, or job search automation inquiries.",
   robots: {
@@ -15,7 +15,7 @@ export const metadata: Metadata = {
     canonical: "https://www.flashfirejobs.com/en-ca/contact-us",
   },
   openGraph: {
-    title: "Contact Us - Flashfire Canada",
+    title: "Contact Flashfire: Get in Touch | Flashfire Canada",
     description:
       "Talk to Flashfire’s Canada team for support, partnerships, or general questions.",
     url: "https://www.flashfirejobs.com/en-ca/contact-us",

--- a/app/en-ca/employers/page.tsx
+++ b/app/en-ca/employers/page.tsx
@@ -4,7 +4,7 @@ import Footer from "@/src/components/footer/footer";
 import Navbar from "@/src/components/navbar/navbar";
 
 export const metadata: Metadata = {
-  title: "Employers - Partner with Flashfire | Hire Top Talent Faster",
+  title: "Flashfire for Employers: Hire Top Talent Faster",
   description:
     "Partner with Flashfire to access pre-screened, qualified candidates. Connect with job seekers actively applying to roles in your industry.",
   robots: {
@@ -15,7 +15,7 @@ export const metadata: Metadata = {
     canonical: "https://www.flashfirejobs.com/en-ca/employers",
   },
   openGraph: {
-    title: "Employers - Partner with Flashfire",
+    title: "Flashfire for Employers: Hire Top Talent Faster",
     description:
       "Partner with Flashfire to access pre-screened, qualified candidates.",
     url: "https://www.flashfirejobs.com/en-ca/employers",

--- a/app/en-ca/faq/page.tsx
+++ b/app/en-ca/faq/page.tsx
@@ -3,7 +3,7 @@ import CanadaHome from "@/src/components/countries/ca/Home";
 import ScrollToSection from "@/src/utils/ui/scrollToSection";
 
 export const metadata: Metadata = {
-  title: "FAQ - Frequently Asked Questions | Flashfire Job Search Automation",
+  title: "Flashfire FAQs: AI Job Search Questions Answered",
   description:
     "Find answers to common questions about Flashfire's job search automation service, pricing, how it works, and more.",
   robots: {
@@ -14,7 +14,7 @@ export const metadata: Metadata = {
     canonical: "https://www.flashfirejobs.com/en-ca/faq",
   },
   openGraph: {
-    title: "FAQ - Frequently Asked Questions",
+    title: "Flashfire FAQs: AI Job Search Questions Answered",
     description:
       "Find answers to common questions about Flashfire's job search automation.",
     url: "https://www.flashfirejobs.com/en-ca/faq",
@@ -23,8 +23,96 @@ export const metadata: Metadata = {
 };
 
 export default function FAQPageCA() {
+  const schema = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "Why are we the best job hunting site to find opportunities quickly?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Because we don't just show jobs — we apply to them for you. You skip browsing, resume editing, and forms. We do it all."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "How does an AI-powered job search improve my chances of finding relevant positions?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "AI-powered job search uses intelligent matching, resume optimization, and automation to apply only to roles that fit your profile. Flashfire's AI-powered job search ensures higher relevance and better recruiter response rates."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Can AI job application tools help me apply for jobs faster?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Yes. Job search automation allows AI to apply for jobs automatically on your behalf, saving time while increasing application volume and accuracy."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What are the benefits of using AI for job search on FlashFireJobs?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Using AI for job search on FlashFireJobs offers several benefits, including personalized job recommendations, faster applications, and improved recruiter visibility. As an AI-powered job search platform, FlashFireJobs combines intelligent job discovery, AI resume matching, and automated applications to help modern job seekers find opportunities quickly and apply with confidence."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Does FlashFireJobs act as an AI job board?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Flashfire works as an AI job search platform, combining job discovery, AI job matching, and automated applications."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "How does an AI-powered job search differ from traditional job searching?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Traditional job searching is manual and time-consuming. AI-powered job search automates resume matching, job applications, and tracking, making job search automation faster and more effective."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What is a job search virtual assistant and how can it make job hunting easier?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "FlashFireJobs acts as your virtual assistant and team — finding jobs, optimizing your resume, and applying for you every day."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Can FlashFireJobs auto apply to jobs on my behalf?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Yes. Flashfire is an AI job application platform that can auto-apply to jobs using AI-driven resume matching and role-specific optimization."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What job application assistance features does FlashFireJobs offer?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "✔️ Resume optimization ✔️ Cover letter submission ✔️ 1,200+ manual applications ✔️ LinkedIn profile tips ✔️ Live job tracker ✔️ WhatsApp support ✔️ Weekly progress updates"
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Which is the best app to find job opportunities in my field?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "FlashFireJobs is ideal if you want results. We don't show jobs — we apply to them with tailored resumes and real human effort."
+        }
+      }
+    ]
+  };
+
   return (
     <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }} />
       <CanadaHome />
       <ScrollToSection targetId="faq" />
     </>

--- a/app/en-ca/features/cover-letter/page.tsx
+++ b/app/en-ca/features/cover-letter/page.tsx
@@ -3,7 +3,7 @@ import { Metadata } from "next";
 export { default } from "@/app/features/cover-letter/page";
 
 export const metadata: Metadata = {
-  title: "Cover Letter Builder - Persuasive Letters in Minutes | Flashfire Canada",
+  title: "AI Cover Letter Builder | Flashfire Canada",
   description:
     "Generate personalized cover letters tailored to each Canadian role without writing from scratch. Flashfire keeps tone, proof, and keywords on point.",
   robots: {
@@ -14,7 +14,7 @@ export const metadata: Metadata = {
     canonical: "https://www.flashfirejobs.com/en-ca/features/cover-letter",
   },
   openGraph: {
-    title: "Cover Letter Builder - Personalized & Proof-Based",
+    title: "AI Cover Letter Builder | Flashfire Canada",
     description:
       "Craft compelling cover letters fast using Flashfire’s AI + human review workflow designed for Canadian employers.",
     url: "https://www.flashfirejobs.com/en-ca/features/cover-letter",

--- a/app/en-ca/features/dashboard-analytics/page.tsx
+++ b/app/en-ca/features/dashboard-analytics/page.tsx
@@ -3,7 +3,7 @@ import { Metadata } from "next";
 export { default } from "@/app/features/dashboard-analytics/page";
 
 export const metadata: Metadata = {
-  title: "Dashboard & Analytics - Stay in Control of Your Search | Flashfire Canada",
+  title: "Job Application Dashboard & Analytics | Flashfire CA",
   description:
     "See every Canadian application, pipeline stage, and conversion metric in one analytics dashboard so you always know what's next.",
   robots: {
@@ -14,7 +14,7 @@ export const metadata: Metadata = {
     canonical: "https://www.flashfirejobs.com/en-ca/features/dashboard-analytics",
   },
   openGraph: {
-    title: "Dashboard & Analytics - Real-Time Visibility",
+    title: "Job Application Dashboard & Analytics | Flashfire CA",
     description:
       "Track applications, interviews, and wins through Flashfire’s live analytics dashboard built for job seekers.",
     url: "https://www.flashfirejobs.com/en-ca/features/dashboard-analytics",

--- a/app/en-ca/features/interview-tips/page.tsx
+++ b/app/en-ca/features/interview-tips/page.tsx
@@ -2,7 +2,7 @@ import { Metadata } from "next";
 export { default } from "@/app/features/interview-tips/page";
 
 export const metadata: Metadata = {
-    title: "Interview Tips - Flashfire",
+    title: "Interview Tips for Canadian Job Seekers | Flashfire",
     description: "Interview Tips - Flashfire",
     robots: {
         index: true,
@@ -12,7 +12,7 @@ export const metadata: Metadata = {
         canonical: "https://www.flashfirejobs.com/en-ca/features/interview-tips",
     },
     openGraph: {
-        title: "Interview Tips - Flashfire",
+        title: "Interview Tips for Canadian Job Seekers | Flashfire",
         description: "Interview Tips - Flashfire",
         url: "https://www.flashfirejobs.com/en-ca/features/interview-tips",
         siteName: "Flashfire",
@@ -22,7 +22,7 @@ export const metadata: Metadata = {
     },
     twitter: {
         card: "summary_large_image",
-        title: "Interview Tips - Flashfire",
+        title: "Interview Tips for Canadian Job Seekers | Flashfire",
         description: "Interview Tips - Flashfire",
         images: [
             { url: "https://www.flashfirejobs.com/og-image.png" },

--- a/app/en-ca/features/job-automation/page.tsx
+++ b/app/en-ca/features/job-automation/page.tsx
@@ -3,7 +3,7 @@ import { Metadata } from "next";
 export { default } from "@/app/features/job-automation/page";
 
 export const metadata: Metadata = {
-  title: "Job Automation - Apply to 1,000+ Roles Without the Grind | Flashfire Canada",
+  title: "Automated Job Applications: Apply to 1000+ Roles",
   description:
     "Flashfire sources high-fit Canadian roles, tailors your assets, and applies on your behalf so you land interviews while saving 150+ hours.",
   robots: {
@@ -14,7 +14,7 @@ export const metadata: Metadata = {
     canonical: "https://www.flashfirejobs.com/en-ca/features/job-automation",
   },
   openGraph: {
-    title: "Job Automation - Let Flashfire Apply for You",
+    title: "Automated Job Applications: Apply to 1000+ Roles",
     description:
       "Scale your job hunt with human-powered, AI-assisted application automation purpose-built for Canadian job seekers.",
     url: "https://www.flashfirejobs.com/en-ca/features/job-automation",

--- a/app/en-ca/features/job-tracker/page.tsx
+++ b/app/en-ca/features/job-tracker/page.tsx
@@ -3,7 +3,7 @@ import { Metadata } from "next";
 export { default } from "@/app/features/job-tracker/page";
 
 export const metadata: Metadata = {
-  title: "Job Tracker - Real-Time Application Dashboard | Flashfire Canada",
+  title: "Real-Time AI Job Tracker Dashboard | Flashfire CA",
   description:
     "Monitor every Canadian application in one live dashboard with status updates, recruiter notes, and reminders so nothing slips.",
   robots: {
@@ -14,7 +14,7 @@ export const metadata: Metadata = {
     canonical: "https://www.flashfirejobs.com/en-ca/features/job-tracker",
   },
   openGraph: {
-    title: "Job Tracker - Real-Time Application Dashboard",
+    title: "Real-Time AI Job Tracker Dashboard | Flashfire CA",
     description:
       "Track submissions, interviews, and outcomes across every job Flashfire applies to on your behalf.",
     url: "https://www.flashfirejobs.com/en-ca/features/job-tracker",

--- a/app/en-ca/features/linkedin-profile-optimization/page.tsx
+++ b/app/en-ca/features/linkedin-profile-optimization/page.tsx
@@ -3,7 +3,7 @@ import { Metadata } from "next";
 export { default } from "@/app/features/linkedin-profile-optimization/page";
 
 export const metadata: Metadata = {
-  title: "LinkedIn Optimization - Stand Out to Canadian Recruiters | Flashfire",
+  title: "LinkedIn Optimization for Canadian Recruiters",
   description:
     "Refresh your LinkedIn profile with recruiter-ready headlines, summaries, and keywords so Canadian hiring teams can find and trust you faster.",
   robots: {
@@ -14,7 +14,7 @@ export const metadata: Metadata = {
     canonical: "https://www.flashfirejobs.com/en-ca/features/linkedin-profile-optimization",
   },
   openGraph: {
-    title: "LinkedIn Optimization - Stand Out to Recruiters",
+    title: "LinkedIn Optimization for Canadian Recruiters",
     description:
       "Polish your LinkedIn presence with ATS-aligned keywords, proof-backed bullets, and an irresistible summary tailored for Canada.",
     url: "https://www.flashfirejobs.com/en-ca/features/linkedin-profile-optimization",

--- a/app/en-ca/features/page.tsx
+++ b/app/en-ca/features/page.tsx
@@ -4,7 +4,7 @@ import Footer from "@/src/components/footer/footer";
 import Features from "@/src/components/pages/features/Features";
 
 export const metadata: Metadata = {
-  title: "Features - Why Choose Flashfire",
+  title: "Flashfire Features: Why Choose Our AI Job Search Tool",
   description:
     "Explore Flashfire's key features: AI-powered matching, dynamic resume optimization, LinkedIn optimization, precision targeting, and more.",
   alternates: {

--- a/app/en-ca/features/precision-targeting/page.tsx
+++ b/app/en-ca/features/precision-targeting/page.tsx
@@ -3,7 +3,7 @@ import { Metadata } from "next";
 export { default } from "@/app/features/precision-targeting/page";
 
 export const metadata: Metadata = {
-  title: "Precision Targeting - Find the Right Canadian Roles | Flashfire",
+  title: "Precision Job Targeting: Find Canadian Roles",
   description:
     "Flashfire pinpoints roles that match your visa status, salary goals, and tech stack so every application is high intent.",
   robots: {
@@ -14,7 +14,7 @@ export const metadata: Metadata = {
     canonical: "https://www.flashfirejobs.com/en-ca/features/precision-targeting",
   },
   openGraph: {
-    title: "Precision Targeting - Hyper-Relevant Job Matching",
+    title: "Precision Job Targeting: Find Canadian Roles",
     description:
       "Use Flashfire’s targeting engine to surface Canadian roles aligned to your background, visa, and compensation needs.",
     url: "https://www.flashfirejobs.com/en-ca/features/precision-targeting",

--- a/app/en-ca/features/resume-optimizer/page.tsx
+++ b/app/en-ca/features/resume-optimizer/page.tsx
@@ -3,7 +3,7 @@ import { Metadata } from "next";
 export { default } from "@/app/features/resume-optimizer/page";
 
 export const metadata: Metadata = {
-  title: "Resume Optimizer - ATS-Friendly Resumes for Every Role | Flashfire Canada",
+  title: "ATS Resume Optimizer & Builder | Flashfire Canada",
   description:
     "Optimize your resume for each job you apply to. Flashfire aligns your experience with every JD so Canadian recruiters and ATS systems say yes.",
   robots: {
@@ -14,7 +14,7 @@ export const metadata: Metadata = {
     canonical: "https://www.flashfirejobs.com/en-ca/features/resume-optimizer",
   },
   openGraph: {
-    title: "Resume Optimizer - ATS-Friendly Resumes for Every Role",
+    title: "ATS Resume Optimizer & Builder | Flashfire Canada",
     description:
       "Automatically tailor your resume to each job description and pass every ATS filter with Flashfire.",
     url: "https://www.flashfirejobs.com/en-ca/features/resume-optimizer",

--- a/app/en-ca/get-me-interview/page.tsx
+++ b/app/en-ca/get-me-interview/page.tsx
@@ -3,7 +3,7 @@ import { Metadata } from "next";
 export { default } from "@/app/get-me-interview/page";
 
 export const metadata: Metadata = {
-  title: "Get Me Interview - Flashfire Job Search Automation (Canada)",
+  title: "Get Me an Interview | Flashfire Canada",
   description:
     "Unlock Flashfire’s human-powered, AI-assisted job search system built for Canadian job seekers. Track every application and land interviews faster.",
   robots: {
@@ -14,7 +14,7 @@ export const metadata: Metadata = {
     canonical: "https://www.flashfirejobs.com/en-ca/get-me-interview",
   },
   openGraph: {
-    title: "Get Me Interview - Flashfire Canada",
+    title: "Get Me an Interview | Flashfire Canada",
     description:
       "Activate Flashfire’s end-to-end job application engine: resume tailoring, job automation, tracking, and updates—all for Canada.",
     url: "https://www.flashfirejobs.com/en-ca/get-me-interview",

--- a/app/en-ca/how-flashfire-ai-job-automation-platform-works/page.tsx
+++ b/app/en-ca/how-flashfire-ai-job-automation-platform-works/page.tsx
@@ -2,8 +2,7 @@ import { Metadata } from "next";
 import HowItWorks from "@/src/components/pages/howItWorks/HowItWorks";
 
 export const metadata: Metadata = {
-  title:
-    "How It Works - Flashfire Job Search Automation for Students | Flashfire",
+  title: "How It Works: Student Job Search Automation",
   description:
     "See how Flashfire gets international students interview calls faster: visa-aware matching, ATS-ready resumes, automated applications, tracking, and interview prep.",
   robots: {
@@ -14,7 +13,7 @@ export const metadata: Metadata = {
     canonical: "https://www.flashfirejobs.com/en-ca/how-flashfire-ai-job-automation-platform-works",
   },
   openGraph: {
-    title: "How It Works - Flashfire Job Search Automation",
+    title: "How It Works: Student Job Search Automation",
     description:
       "Understand how Flashfire automates sourcing, tailoring, and submitting applications so students land interviews faster.",
     url: "https://www.flashfirejobs.com/en-ca/how-flashfire-ai-job-automation-platform-works",

--- a/app/en-ca/how-it-works/page.tsx
+++ b/app/en-ca/how-it-works/page.tsx
@@ -2,8 +2,7 @@ import { Metadata } from "next";
 import HowItWorks from "@/src/components/pages/howItWorks/HowItWorks";
 
 export const metadata: Metadata = {
-  title:
-    "How It Works - Flashfire Job Search Automation for Students | Flashfire",
+  title: "How It Works: Student Job Search Automation",
   description:
     "See how Flashfire gets international students interview calls faster: visa-aware matching, ATS-ready resumes, automated applications, tracking, and interview prep.",
   robots: {
@@ -14,7 +13,7 @@ export const metadata: Metadata = {
     canonical: "https://www.flashfirejobs.com/en-ca/how-it-works",
   },
   openGraph: {
-    title: "How It Works - Flashfire Job Search Automation",
+    title: "How It Works: Student Job Search Automation",
     description:
       "Understand how Flashfire automates sourcing, tailoring, and submitting applications so students land interviews faster.",
     url: "https://www.flashfirejobs.com/en-ca/how-it-works",

--- a/app/en-ca/image-testimonials/page.tsx
+++ b/app/en-ca/image-testimonials/page.tsx
@@ -4,7 +4,7 @@ import Footer from "@/src/components/footer/footer";
 import HappyUsersGalleryPage from "@/src/components/homePageHappyUsers/HappyUsersGalleryPage";
 
 export const metadata: Metadata = {
-  title: "Success Stories & Testimonials | Flashfire",
+  title: "Flashfire Reviews: Success Stories & Testimonials",
   description:
     "See real success stories from job seekers who landed their dream jobs with Flashfire. Read testimonials from professionals who automated their job search and saved 150+ hours.",
   robots: {
@@ -15,7 +15,7 @@ export const metadata: Metadata = {
     canonical: "https://www.flashfirejobs.com/en-ca/image-testimonials",
   },
   openGraph: {
-    title: "Success Stories & Testimonials | Flashfire",
+    title: "Flashfire Reviews: Success Stories & Testimonials",
     description:
       "See real success stories from job seekers who landed their dream jobs with Flashfire.",
     url: "https://www.flashfirejobs.com/en-ca/image-testimonials",

--- a/app/en-ca/job-search/page.tsx
+++ b/app/en-ca/job-search/page.tsx
@@ -4,7 +4,7 @@ import Footer from "@/src/components/footer/footer";
 import JobSearch from "@/src/components/pages/jobSearch/JobSearch";
 
 export const metadata: Metadata = {
-  title: "Job Search - Find Jobs Faster With Human-Powered Automation | Flashfire",
+  title: "Job Search: Faster Human-Powered Automation",
   description:
     "Flashfire applies to relevant jobs on your behalf so you don't have to search manually. Get updates without lifting a finger.",
   robots: {
@@ -15,7 +15,7 @@ export const metadata: Metadata = {
     canonical: "https://www.flashfirejobs.com/en-ca/job-search",
   },
   openGraph: {
-    title: "Job Search - Find Jobs Faster With Human-Powered Automation",
+    title: "Job Search: Faster Human-Powered Automation",
     description:
       "Flashfire applies to relevant jobs on your behalf so you don't have to search manually.",
     url: "https://www.flashfirejobs.com/en-ca/job-search",

--- a/app/en-ca/offer-and-salary/page.tsx
+++ b/app/en-ca/offer-and-salary/page.tsx
@@ -4,7 +4,7 @@ import Footer from "@/src/components/footer/footer";
 import Navbar from "@/src/components/navbar/navbar";
 
 export const metadata: Metadata = {
-    title: "Offer & Salary - Flashfire",
+    title: "Job Offer & Salary Negotiation | Flashfire",
     description: "Offer & Salary - Flashfire",
     robots: {
         index: true,
@@ -14,7 +14,7 @@ export const metadata: Metadata = {
         canonical: "https://www.flashfirejobs.com/en-ca/offer-and-salary",
     },
     openGraph: {
-        title: "Offer & Salary - Flashfire",
+        title: "Job Offer & Salary Negotiation | Flashfire",
         description: "Offer & Salary - Flashfire",
         url: "https://www.flashfirejobs.com/offer-and-salary",
         siteName: "Flashfire",
@@ -24,7 +24,7 @@ export const metadata: Metadata = {
     },
     twitter: {
         card: "summary_large_image",
-        title: "Offer & Salary - Flashfire",
+        title: "Job Offer & Salary Negotiation | Flashfire",
         description: "Offer & Salary - Flashfire",
         images: [
             { url: "https://www.flashfirejobs.com/og-image.png" },

--- a/app/en-ca/page.tsx
+++ b/app/en-ca/page.tsx
@@ -2,7 +2,7 @@ import { Metadata } from "next";
 import CanadaHome from "@/src/components/countries/ca/Home";
 
 export const metadata: Metadata = {
-  title: "FLASHFIRE - AI-Powered Job Search Automation | Land Your Dream Job Faster (Canada)",
+  title: "Flashfire: AI Job Search Automation Canada",
   description:
     "We apply to 1000+ jobs on your behalf with tailored resumes for every role. Save 150+ hours, skip the grunt work, and stay in control with real-time updates. Your job hunt—automated.",
   robots: {
@@ -13,7 +13,7 @@ export const metadata: Metadata = {
     canonical: "https://www.flashfirejobs.com/en-ca",
   },
   openGraph: {
-    title: "FLASHFIRE - AI-Powered Job Search Automation (Canada)",
+    title: "Flashfire: AI Job Search Automation Canada",
     description:
       "We apply to 1000+ jobs on your behalf with tailored resumes for every role. Save 150+ hours, skip the grunt work, and stay in control with real-time updates.",
     url: "https://www.flashfirejobs.com/en-ca",

--- a/app/en-ca/pricing/page.tsx
+++ b/app/en-ca/pricing/page.tsx
@@ -8,7 +8,7 @@ import HomePageFoundersNote from "@/src/components/homePageFoundersNote/homePage
 import HomePageFAQ from "@/src/components/homePageFAQ/homePageFAQ";
 
 export const metadata: Metadata = {
-  title: "Pricing - Affordable Job Search Automation Plans | Flashfire CA",
+  title: "Flashfire CA Pricing: Affordable Job Automation Plans",
   description:
     "Choose the perfect Flashfire plan for your job search. Transparent pricing with flexible options to automate your job applications and save time.",
   robots: {
@@ -19,7 +19,7 @@ export const metadata: Metadata = {
     canonical: "https://www.flashfirejobs.com/en-ca/pricing",
   },
   openGraph: {
-    title: "Pricing - Affordable Job Search Automation Plans",
+    title: "Flashfire CA Pricing: Affordable Job Automation Plans",
     description:
       "Choose the perfect Flashfire plan for your job search automation.",
     url: "https://www.flashfirejobs.com/en-ca/pricing",
@@ -28,8 +28,57 @@ export const metadata: Metadata = {
 };
 
 export default function PricingPageCA() {
+  const softwareApplicationSchema = {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "Flashfire",
+    "url": "https://www.flashfirejobs.com/en-ca/pricing",
+    "applicationCategory": "BusinessApplication",
+    "operatingSystem": "Web",
+    "description": "AI-powered job search automation platform that finds jobs, optimizes resumes, and applies to roles on your behalf — for Canadian job seekers.",
+    "offers": [
+      {
+        "@type": "Offer",
+        "name": "PRIME",
+        "price": "139",
+        "priceCurrency": "CAD",
+        "url": "https://www.flashfirejobs.com/en-ca/pricing",
+        "availability": "https://schema.org/InStock",
+        "category": "OneTime"
+      },
+      {
+        "@type": "Offer",
+        "name": "IGNITE",
+        "price": "239",
+        "priceCurrency": "CAD",
+        "url": "https://www.flashfirejobs.com/en-ca/pricing",
+        "availability": "https://schema.org/InStock",
+        "category": "OneTime"
+      },
+      {
+        "@type": "Offer",
+        "name": "PROFESSIONAL",
+        "price": "409",
+        "priceCurrency": "CAD",
+        "url": "https://www.flashfirejobs.com/en-ca/pricing",
+        "availability": "https://schema.org/InStock",
+        "category": "OneTime"
+      },
+      {
+        "@type": "Offer",
+        "name": "EXECUTIVE",
+        "price": "799",
+        "priceCurrency": "CAD",
+        "url": "https://www.flashfirejobs.com/en-ca/pricing",
+        "availability": "https://schema.org/InStock",
+        "category": "OneTime"
+      }
+    ]
+  };
+
   return (
     <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(softwareApplicationSchema) }} />
       <Navbar />
       <HomePagePricingPlans />
       <HomePageOfferLetters

--- a/app/en-ca/recent-job-openings/page.tsx
+++ b/app/en-ca/recent-job-openings/page.tsx
@@ -3,7 +3,7 @@ import RecentJobOpenings from "@/src/components/recentJobOpenings/recentJobOpeni
 import Footer from "@/src/components/footer/footer";
 import Navbar from "@/src/components/navbar/navbar";
 export const metadata: Metadata = {
-    title: "Recent Job Openings - Flashfire",
+    title: "Recent Canadian Job Openings | Flashfire",
     description: "Recent Job Openings - Flashfire",
     robots: {
         index: true,
@@ -13,7 +13,7 @@ export const metadata: Metadata = {
         canonical: "https://www.flashfirejobs.com/en-ca/recent-job-openings",
     },
     openGraph: {
-        title: "Recent Job Openings - Flashfire",
+        title: "Recent Canadian Job Openings | Flashfire",
         description: "Recent Job Openings - Flashfire",
         url: "https://www.flashfirejobs.com/recent-job-openings",
         siteName: "Flashfire",
@@ -23,7 +23,7 @@ export const metadata: Metadata = {
     },
     twitter: {
         card: "summary_large_image",
-        title: "Recent Job Openings - Flashfire",
+        title: "Recent Canadian Job Openings | Flashfire",
         description: "Recent Job Openings - Flashfire",
         images: [
             { url: "https://www.flashfirejobs.com/images/og-image.png" },

--- a/app/en-ca/see-flashfire-in-action/page.tsx
+++ b/app/en-ca/see-flashfire-in-action/page.tsx
@@ -3,7 +3,7 @@ import HomePage from "@/src/components/pages/home/Home";
 import ScrollToSection from "@/src/utils/ui/scrollToSection";
 
 export const metadata: Metadata = {
-  title: "See Flashfire in Action - Live Demo & Product Tour | Flashfire",
+  title: "Watch Flashfire Live Demo & Product Tour",
   description:
     "Watch Flashfire in action. See how our AI-powered job search automation works with a live demo of our platform features.",
   robots: {
@@ -14,7 +14,7 @@ export const metadata: Metadata = {
     canonical: "https://www.flashfirejobs.com/en-ca/see-flashfire-in-action",
   },
   openGraph: {
-    title: "See Flashfire in Action - Live Demo & Product Tour",
+    title: "Watch Flashfire Live Demo & Product Tour",
     description:
       "Watch Flashfire in action with a live demo of our platform.",
     url: "https://www.flashfirejobs.com/en-ca/see-flashfire-in-action",

--- a/app/en-ca/testimonials/page.tsx
+++ b/app/en-ca/testimonials/page.tsx
@@ -4,7 +4,7 @@ import Footer from "@/src/components/footer/footer";
 import HappyUsersGalleryPage from "@/src/components/homePageHappyUsers/HappyUsersGalleryPage";
 
 export const metadata: Metadata = {
-  title: "Success Stories & Testimonials | Flashfire",
+  title: "Flashfire Reviews: Success Stories & Testimonials",
   description:
     "See real success stories from job seekers who landed their dream jobs with Flashfire. Read testimonials from professionals who automated their job search and saved 150+ hours.",
   robots: {
@@ -15,7 +15,7 @@ export const metadata: Metadata = {
     canonical: "https://www.flashfirejobs.com/en-ca/testimonials",
   },
   openGraph: {
-    title: "Success Stories & Testimonials | Flashfire",
+    title: "Flashfire Reviews: Success Stories & Testimonials",
     description:
       "See real success stories from job seekers who landed their dream jobs with Flashfire.",
     url: "https://www.flashfirejobs.com/en-ca/testimonials",

--- a/app/faq/page.tsx
+++ b/app/faq/page.tsx
@@ -15,7 +15,7 @@ export const metadata: Metadata = {
     canonical: "https://www.flashfirejobs.com/faq",
   },
   openGraph: {
-    title: "FAQ - Frequently Asked Questions",
+    title: "FAQ — Flashfire Job Search Automation",
     description:
       "Find answers to common questions about Flashfire's job search automation.",
     url: "https://www.flashfirejobs.com/faq",
@@ -30,74 +30,82 @@ export default function FAQPage() {
     "mainEntity": [
       {
         "@type": "Question",
-        "name": "How does Flashfire's job search automation work?",
+        "name": "Why are we the best job hunting site to find opportunities quickly?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Flashfire uses AI to find relevant job listings, optimizes your resume for each role, and our human team manually submits tailored applications on your behalf — so you get interviews without spending hours applying."
+          "text": "Because we don't just show jobs — we apply to them for you. You skip browsing, resume editing, and forms. We do it all."
         }
       },
       {
         "@type": "Question",
-        "name": "How many jobs does Flashfire apply to per week?",
+        "name": "How does an AI-powered job search improve my chances of finding relevant positions?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Flashfire applies to 200–400+ targeted jobs per month on your behalf, focusing on roles that match your profile, experience, and preferences."
+          "text": "AI-powered job search uses intelligent matching, resume optimization, and automation to apply only to roles that fit your profile. Flashfire's AI-powered job search ensures higher relevance and better recruiter response rates."
         }
       },
       {
         "@type": "Question",
-        "name": "Does Flashfire customize the resume for each job application?",
+        "name": "Can AI job application tools help me apply for jobs faster?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Yes. Every application submitted through Flashfire includes a resume that is tailored to the specific job description using ATS-optimized keywords relevant to that role."
+          "text": "Yes. Job search automation allows AI to apply for jobs automatically on your behalf, saving time while increasing application volume and accuracy."
         }
       },
       {
         "@type": "Question",
-        "name": "How long does it take to start getting interview calls with Flashfire?",
+        "name": "What are the benefits of using AI for job search on FlashFireJobs?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Most users start receiving interview calls within 2–4 weeks of onboarding, depending on their target roles, location, and how competitive the job market is."
+          "text": "Using AI for job search on FlashFireJobs offers several benefits, including personalized job recommendations, faster applications, and improved recruiter visibility. As an AI-powered job search platform, FlashFireJobs combines intelligent job discovery, AI resume matching, and automated applications to help modern job seekers find opportunities quickly and apply with confidence."
         }
       },
       {
         "@type": "Question",
-        "name": "What is the pricing for Flashfire's job search automation service?",
+        "name": "Does FlashFireJobs act as an AI job board?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Flashfire offers multiple plans based on your job search volume and duration. Visit our pricing page at flashfirejobs.com/pricing for current plan details and pricing."
+          "text": "Flashfire works as an AI job search platform, combining job discovery, AI job matching, and automated applications."
         }
       },
       {
         "@type": "Question",
-        "name": "Does Flashfire work for jobs in Canada?",
+        "name": "How does an AI-powered job search differ from traditional job searching?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Yes. Flashfire supports job seekers in both the US and Canada. Canadian users get a dedicated experience at flashfirejobs.com/en-ca with region-specific job targeting."
+          "text": "Traditional job searching is manual and time-consuming. AI-powered job search automates resume matching, job applications, and tracking, making job search automation faster and more effective."
         }
       },
       {
         "@type": "Question",
-        "name": "Can Flashfire help with LinkedIn profile optimization?",
+        "name": "What is a job search virtual assistant and how can it make job hunting easier?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Yes. Flashfire's LinkedIn profile optimization service restructures your headline, summary, and skills section with recruiter-friendly keywords to improve your visibility in LinkedIn search results."
+          "text": "FlashFireJobs acts as your virtual assistant and team — finding jobs, optimizing your resume, and applying for you every day."
         }
       },
       {
         "@type": "Question",
-        "name": "Is Flashfire suitable for freshers or new graduates?",
+        "name": "Can FlashFireJobs auto apply to jobs on my behalf?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Absolutely. Flashfire is designed to help both experienced professionals and fresh graduates find jobs faster by automating the most time-consuming parts of the job search."
+          "text": "Yes. Flashfire is an AI job application platform that can auto-apply to jobs using AI-driven resume matching and role-specific optimization."
         }
       },
       {
         "@type": "Question",
-        "name": "How do I track the status of my job applications with Flashfire?",
+        "name": "What job application assistance features does FlashFireJobs offer?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Flashfire provides a real-time dashboard where you can track all applications submitted on your behalf, see which companies have responded, and monitor your interview conversion rate."
+          "text": "✔️ Resume optimization ✔️ Cover letter submission ✔️ 1,200+ manual applications ✔️ LinkedIn profile tips ✔️ Live job tracker ✔️ WhatsApp support ✔️ Weekly progress updates"
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Which is the best app to find job opportunities in my field?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "FlashFireJobs is ideal if you want results. We don't show jobs — we apply to them with tailored resumes and real human effort."
         }
       }
     ]

--- a/app/job-search/page.tsx
+++ b/app/job-search/page.tsx
@@ -15,7 +15,7 @@ export const metadata: Metadata = {
     canonical: "https://www.flashfirejobs.com/job-search",
   },
   openGraph: {
-    title: "Job Search - Find Jobs Faster With Human-Powered Automation",
+    title: "AI Job Search — Apply Faster With Flashfire",
     description:
       "Flashfire applies to relevant jobs on your behalf so you don't have to search manually.",
     url: "https://www.flashfirejobs.com/job-search",

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -34,7 +34,7 @@ export const metadata: Metadata = {
 };
 
 export default function PricingPage() {
-  const schema = {
+  const webPageSchema = {
     "@context": "https://schema.org",
     "@type": "WebPage",
     "name": "Pricing - Affordable Job Search Automation Plans | Flashfire",
@@ -47,9 +47,58 @@ export default function PricingPage() {
     }
   };
 
+  const softwareApplicationSchema = {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "Flashfire",
+    "url": "https://www.flashfirejobs.com/pricing",
+    "applicationCategory": "BusinessApplication",
+    "operatingSystem": "Web",
+    "description": "AI-powered job search automation platform that finds jobs, optimizes resumes, and applies to roles on your behalf.",
+    "offers": [
+      {
+        "@type": "Offer",
+        "name": "PRIME",
+        "price": "99",
+        "priceCurrency": "USD",
+        "url": "https://www.flashfirejobs.com/pricing",
+        "availability": "https://schema.org/InStock",
+        "category": "OneTime"
+      },
+      {
+        "@type": "Offer",
+        "name": "IGNITE",
+        "price": "199",
+        "priceCurrency": "USD",
+        "url": "https://www.flashfirejobs.com/pricing",
+        "availability": "https://schema.org/InStock",
+        "category": "OneTime"
+      },
+      {
+        "@type": "Offer",
+        "name": "PROFESSIONAL",
+        "price": "349",
+        "priceCurrency": "USD",
+        "url": "https://www.flashfirejobs.com/pricing",
+        "availability": "https://schema.org/InStock",
+        "category": "OneTime"
+      },
+      {
+        "@type": "Offer",
+        "name": "EXECUTIVE",
+        "price": "599",
+        "priceCurrency": "USD",
+        "url": "https://www.flashfirejobs.com/pricing",
+        "availability": "https://schema.org/InStock",
+        "category": "OneTime"
+      }
+    ]
+  };
+
   return (
     <>
-      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(webPageSchema) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(softwareApplicationSchema) }} />
       <PricingPageClient />
     </>
   );

--- a/app/testimonials/page.tsx
+++ b/app/testimonials/page.tsx
@@ -65,31 +65,11 @@ export default function TestimonialsPage() {
     }
   };
 
-  const aggregateRatingSchema = {
-    "@context": "https://schema.org",
-    "@type": "Product",
-    "name": "Flashfire",
-    "url": "https://www.flashfirejobs.com/",
-    "description": "AI-powered job application service that automates job search and resume optimization to help you land interviews faster.",
-    "image": "https://www.flashfirejobs.com/images/og-image.png",
-    "aggregateRating": {
-      "@type": "AggregateRating",
-      "ratingValue": "4.8",
-      "reviewCount": "200",
-      "bestRating": "5",
-      "worstRating": "1"
-    }
-  };
-
   return (
     <>
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(reviewSchema) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(aggregateRatingSchema) }}
       />
       <TestimonialImagePreloader />
       <Navbar />


### PR DESCRIPTION
…iew count

- Shortened all /en-ca page titles to <60 chars per SEO audit (P0 #1, P1 #4, P2 #6)
- Trimmed openGraph titles on /job-search and /faq (US)
- Replaced /faq FAQPage schema with finalized 10-question set (P1 #3)
- Added FAQPage schema to /en-ca/faq (previously had none) (P1 #3)
- Removed AggregateRating schema with unverified reviewCount: 200 from /testimonials (P0 #2)
- Added SoftwareApplication schema with real plan prices to /pricing (US, USD) and /en-ca/pricing (CA, CAD) (P2 #8)