### PR TITLE
perf+seo: hreflang, homepage FAQ schema, Calendly CSS unblocked

### DIFF
--- a/app/AI-copilot/page.tsx
+++ b/app/AI-copilot/page.tsx
@@ -12,6 +12,11 @@ export const metadata: Metadata = {
   },
   alternates: {
     canonical: "https://www.flashfirejobs.com/AI-copilot",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/AI-copilot",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/AI-copilot",
+      "x-default": "https://www.flashfirejobs.com/AI-copilot",
+    },
   },
   openGraph: {
     title: "AI Job Application Automation Software & Job Search Platform",

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -18,6 +18,11 @@ export const metadata: Metadata = {
   },
   alternates: {
     canonical: "https://www.flashfirejobs.com/blog",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/blog",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/blog",
+      "x-default": "https://www.flashfirejobs.com/blog",
+    },
   },
   openGraph: {
     title: "Blog - Career Tips & Job Search Advice",

--- a/app/career-advisor/page.tsx
+++ b/app/career-advisor/page.tsx
@@ -12,6 +12,11 @@ export const metadata: Metadata = {
     },
     alternates: {
         canonical: "https://www.flashfirejobs.com/career-advisor",
+        languages: {
+            "en-US": "https://www.flashfirejobs.com/career-advisor",
+            "en-CA": "https://www.flashfirejobs.com/en-ca/career-advisor",
+            "x-default": "https://www.flashfirejobs.com/career-advisor",
+        },
     },
     openGraph: {
         title: "AI Career Advisor & Career Guidance Platform",

--- a/app/contact-us/page.tsx
+++ b/app/contact-us/page.tsx
@@ -13,6 +13,11 @@ export const metadata: Metadata = {
   },
   alternates: {
     canonical: "https://www.flashfirejobs.com/contact-us",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/contact-us",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/contact-us",
+      "x-default": "https://www.flashfirejobs.com/contact-us",
+    },
   },
   openGraph: {
     title: "Flashfire Contact | Customer Support & Enquiries",

--- a/app/employers/page.tsx
+++ b/app/employers/page.tsx
@@ -13,6 +13,11 @@ export const metadata: Metadata = {
   },
   alternates: {
     canonical: "https://www.flashfirejobs.com/employers",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/employers",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/employers",
+      "x-default": "https://www.flashfirejobs.com/employers",
+    },
   },
   openGraph: {
     title: "Employers - Partner with Flashfire",

--- a/app/en-ca/AI-copilot/page.tsx
+++ b/app/en-ca/AI-copilot/page.tsx
@@ -12,6 +12,11 @@ const metadata: Metadata = {
   },
   alternates: {
     canonical: "https://www.flashfirejobs.com/en-ca/AI-copilot",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/AI-copilot",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/AI-copilot",
+      "x-default": "https://www.flashfirejobs.com/AI-copilot",
+    },
   },
   openGraph: {
     title: "AI Copilot: Personalized Interview Tips | Flashfire",

--- a/app/en-ca/blog/page.tsx
+++ b/app/en-ca/blog/page.tsx
@@ -14,6 +14,11 @@ export const metadata: Metadata = {
   },
   alternates: {
     canonical: "https://www.flashfirejobs.com/en-ca/blog",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/blog",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/blog",
+      "x-default": "https://www.flashfirejobs.com/blog",
+    },
   },
   openGraph: {
     title: "Flashfire Blog: Canadian Career Tips & Job Advice",

--- a/app/en-ca/career-advisor/page.tsx
+++ b/app/en-ca/career-advisor/page.tsx
@@ -12,6 +12,11 @@ export const metadata: Metadata = {
     },
     alternates: {
         canonical: "https://www.flashfirejobs.com/en-ca/career-advisor",
+        languages: {
+            "en-US": "https://www.flashfirejobs.com/career-advisor",
+            "en-CA": "https://www.flashfirejobs.com/en-ca/career-advisor",
+            "x-default": "https://www.flashfirejobs.com/career-advisor",
+        },
     },
     openGraph: {
         title: "AI Career Advisor: Personalized Job Recommendations",

--- a/app/en-ca/contact-us/page.tsx
+++ b/app/en-ca/contact-us/page.tsx
@@ -13,6 +13,11 @@ export const metadata: Metadata = {
   },
   alternates: {
     canonical: "https://www.flashfirejobs.com/en-ca/contact-us",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/contact-us",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/contact-us",
+      "x-default": "https://www.flashfirejobs.com/contact-us",
+    },
   },
   openGraph: {
     title: "Contact Flashfire: Get in Touch | Flashfire Canada",

--- a/app/en-ca/employers/page.tsx
+++ b/app/en-ca/employers/page.tsx
@@ -13,6 +13,11 @@ export const metadata: Metadata = {
   },
   alternates: {
     canonical: "https://www.flashfirejobs.com/en-ca/employers",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/employers",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/employers",
+      "x-default": "https://www.flashfirejobs.com/employers",
+    },
   },
   openGraph: {
     title: "Flashfire for Employers: Hire Top Talent Faster",

--- a/app/en-ca/faq/page.tsx
+++ b/app/en-ca/faq/page.tsx
@@ -12,6 +12,11 @@ export const metadata: Metadata = {
   },
   alternates: {
     canonical: "https://www.flashfirejobs.com/en-ca/faq",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/faq",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/faq",
+      "x-default": "https://www.flashfirejobs.com/faq",
+    },
   },
   openGraph: {
     title: "Flashfire FAQs: AI Job Search Questions Answered",

--- a/app/en-ca/features/cover-letter/page.tsx
+++ b/app/en-ca/features/cover-letter/page.tsx
@@ -12,6 +12,11 @@ export const metadata: Metadata = {
   },
   alternates: {
     canonical: "https://www.flashfirejobs.com/en-ca/features/cover-letter",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/features/cover-letter",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/features/cover-letter",
+      "x-default": "https://www.flashfirejobs.com/features/cover-letter",
+    },
   },
   openGraph: {
     title: "AI Cover Letter Builder | Flashfire Canada",

--- a/app/en-ca/features/dashboard-analytics/page.tsx
+++ b/app/en-ca/features/dashboard-analytics/page.tsx
@@ -12,6 +12,11 @@ export const metadata: Metadata = {
   },
   alternates: {
     canonical: "https://www.flashfirejobs.com/en-ca/features/dashboard-analytics",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/features/dashboard-analytics",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/features/dashboard-analytics",
+      "x-default": "https://www.flashfirejobs.com/features/dashboard-analytics",
+    },
   },
   openGraph: {
     title: "Job Application Dashboard & Analytics | Flashfire CA",

--- a/app/en-ca/features/interview-tips/page.tsx
+++ b/app/en-ca/features/interview-tips/page.tsx
@@ -10,6 +10,11 @@ export const metadata: Metadata = {
     },
     alternates: {
         canonical: "https://www.flashfirejobs.com/en-ca/features/interview-tips",
+        languages: {
+            "en-US": "https://www.flashfirejobs.com/features/interview-tips",
+            "en-CA": "https://www.flashfirejobs.com/en-ca/features/interview-tips",
+            "x-default": "https://www.flashfirejobs.com/features/interview-tips",
+        },
     },
     openGraph: {
         title: "Interview Tips for Canadian Job Seekers | Flashfire",

--- a/app/en-ca/features/job-automation/page.tsx
+++ b/app/en-ca/features/job-automation/page.tsx
@@ -12,6 +12,11 @@ export const metadata: Metadata = {
   },
   alternates: {
     canonical: "https://www.flashfirejobs.com/en-ca/features/job-automation",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/features/job-automation",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/features/job-automation",
+      "x-default": "https://www.flashfirejobs.com/features/job-automation",
+    },
   },
   openGraph: {
     title: "Automated Job Applications: Apply to 1000+ Roles",

--- a/app/en-ca/features/job-tracker/page.tsx
+++ b/app/en-ca/features/job-tracker/page.tsx
@@ -12,6 +12,11 @@ export const metadata: Metadata = {
   },
   alternates: {
     canonical: "https://www.flashfirejobs.com/en-ca/features/job-tracker",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/features/job-tracker",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/features/job-tracker",
+      "x-default": "https://www.flashfirejobs.com/features/job-tracker",
+    },
   },
   openGraph: {
     title: "Real-Time AI Job Tracker Dashboard | Flashfire CA",

--- a/app/en-ca/features/linkedin-profile-optimization/page.tsx
+++ b/app/en-ca/features/linkedin-profile-optimization/page.tsx
@@ -12,6 +12,11 @@ export const metadata: Metadata = {
   },
   alternates: {
     canonical: "https://www.flashfirejobs.com/en-ca/features/linkedin-profile-optimization",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/features/linkedin-profile-optimization",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/features/linkedin-profile-optimization",
+      "x-default": "https://www.flashfirejobs.com/features/linkedin-profile-optimization",
+    },
   },
   openGraph: {
     title: "LinkedIn Optimization for Canadian Recruiters",

--- a/app/en-ca/features/page.tsx
+++ b/app/en-ca/features/page.tsx
@@ -9,6 +9,11 @@ export const metadata: Metadata = {
     "Explore Flashfire's key features: AI-powered matching, dynamic resume optimization, LinkedIn optimization, precision targeting, and more.",
   alternates: {
     canonical: "https://www.flashfirejobs.com/en-ca/features",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/features",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/features",
+      "x-default": "https://www.flashfirejobs.com/features",
+    },
   },
 };
 

--- a/app/en-ca/features/precision-targeting/page.tsx
+++ b/app/en-ca/features/precision-targeting/page.tsx
@@ -12,6 +12,11 @@ export const metadata: Metadata = {
   },
   alternates: {
     canonical: "https://www.flashfirejobs.com/en-ca/features/precision-targeting",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/features/precision-targeting",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/features/precision-targeting",
+      "x-default": "https://www.flashfirejobs.com/features/precision-targeting",
+    },
   },
   openGraph: {
     title: "Precision Job Targeting: Find Canadian Roles",

--- a/app/en-ca/features/resume-optimizer/page.tsx
+++ b/app/en-ca/features/resume-optimizer/page.tsx
@@ -12,6 +12,11 @@ export const metadata: Metadata = {
   },
   alternates: {
     canonical: "https://www.flashfirejobs.com/en-ca/features/resume-optimizer",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/features/resume-optimizer",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/features/resume-optimizer",
+      "x-default": "https://www.flashfirejobs.com/features/resume-optimizer",
+    },
   },
   openGraph: {
     title: "ATS Resume Optimizer & Builder | Flashfire Canada",

--- a/app/en-ca/get-me-interview/page.tsx
+++ b/app/en-ca/get-me-interview/page.tsx
@@ -12,6 +12,11 @@ export const metadata: Metadata = {
   },
   alternates: {
     canonical: "https://www.flashfirejobs.com/en-ca/get-me-interview",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/get-me-interview",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/get-me-interview",
+      "x-default": "https://www.flashfirejobs.com/get-me-interview",
+    },
   },
   openGraph: {
     title: "Get Me an Interview | Flashfire Canada",

--- a/app/en-ca/how-flashfire-ai-job-automation-platform-works/page.tsx
+++ b/app/en-ca/how-flashfire-ai-job-automation-platform-works/page.tsx
@@ -11,6 +11,11 @@ export const metadata: Metadata = {
   },
   alternates: {
     canonical: "https://www.flashfirejobs.com/en-ca/how-flashfire-ai-job-automation-platform-works",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/how-flashfire-ai-job-automation-platform-works",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/how-flashfire-ai-job-automation-platform-works",
+      "x-default": "https://www.flashfirejobs.com/how-flashfire-ai-job-automation-platform-works",
+    },
   },
   openGraph: {
     title: "How It Works: Student Job Search Automation",

--- a/app/en-ca/image-testimonials/page.tsx
+++ b/app/en-ca/image-testimonials/page.tsx
@@ -13,6 +13,11 @@ export const metadata: Metadata = {
   },
   alternates: {
     canonical: "https://www.flashfirejobs.com/en-ca/image-testimonials",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/image-testimonials",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/image-testimonials",
+      "x-default": "https://www.flashfirejobs.com/image-testimonials",
+    },
   },
   openGraph: {
     title: "Flashfire Reviews: Success Stories & Testimonials",

--- a/app/en-ca/job-search/page.tsx
+++ b/app/en-ca/job-search/page.tsx
@@ -13,6 +13,11 @@ export const metadata: Metadata = {
   },
   alternates: {
     canonical: "https://www.flashfirejobs.com/en-ca/job-search",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/job-search",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/job-search",
+      "x-default": "https://www.flashfirejobs.com/job-search",
+    },
   },
   openGraph: {
     title: "Job Search: Faster Human-Powered Automation",

--- a/app/en-ca/offer-and-salary/page.tsx
+++ b/app/en-ca/offer-and-salary/page.tsx
@@ -12,6 +12,11 @@ export const metadata: Metadata = {
     },
     alternates: {
         canonical: "https://www.flashfirejobs.com/en-ca/offer-and-salary",
+        languages: {
+            "en-US": "https://www.flashfirejobs.com/offer-and-salary-negotiation-advisor",
+            "en-CA": "https://www.flashfirejobs.com/en-ca/offer-and-salary",
+            "x-default": "https://www.flashfirejobs.com/offer-and-salary-negotiation-advisor",
+        },
     },
     openGraph: {
         title: "Job Offer & Salary Negotiation | Flashfire",

--- a/app/en-ca/page.tsx
+++ b/app/en-ca/page.tsx
@@ -11,6 +11,11 @@ export const metadata: Metadata = {
   },
   alternates: {
     canonical: "https://www.flashfirejobs.com/en-ca",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/",
+      "en-CA": "https://www.flashfirejobs.com/en-ca",
+      "x-default": "https://www.flashfirejobs.com/",
+    },
   },
   openGraph: {
     title: "Flashfire: AI Job Search Automation Canada",

--- a/app/en-ca/pricing/page.tsx
+++ b/app/en-ca/pricing/page.tsx
@@ -17,6 +17,11 @@ export const metadata: Metadata = {
   },
   alternates: {
     canonical: "https://www.flashfirejobs.com/en-ca/pricing",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/pricing",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/pricing",
+      "x-default": "https://www.flashfirejobs.com/pricing",
+    },
   },
   openGraph: {
     title: "Flashfire CA Pricing: Affordable Job Automation Plans",

--- a/app/en-ca/recent-job-openings/page.tsx
+++ b/app/en-ca/recent-job-openings/page.tsx
@@ -11,6 +11,11 @@ export const metadata: Metadata = {
     },
     alternates: {
         canonical: "https://www.flashfirejobs.com/en-ca/recent-job-openings",
+        languages: {
+            "en-US": "https://www.flashfirejobs.com/recent-job-openings",
+            "en-CA": "https://www.flashfirejobs.com/en-ca/recent-job-openings",
+            "x-default": "https://www.flashfirejobs.com/recent-job-openings",
+        },
     },
     openGraph: {
         title: "Recent Canadian Job Openings | Flashfire",

--- a/app/en-ca/see-flashfire-in-action/page.tsx
+++ b/app/en-ca/see-flashfire-in-action/page.tsx
@@ -12,6 +12,11 @@ export const metadata: Metadata = {
   },
   alternates: {
     canonical: "https://www.flashfirejobs.com/en-ca/see-flashfire-in-action",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/see-flashfire-in-action",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/see-flashfire-in-action",
+      "x-default": "https://www.flashfirejobs.com/see-flashfire-in-action",
+    },
   },
   openGraph: {
     title: "Watch Flashfire Live Demo & Product Tour",

--- a/app/en-ca/testimonials/page.tsx
+++ b/app/en-ca/testimonials/page.tsx
@@ -13,6 +13,11 @@ export const metadata: Metadata = {
   },
   alternates: {
     canonical: "https://www.flashfirejobs.com/en-ca/testimonials",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/testimonials",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/testimonials",
+      "x-default": "https://www.flashfirejobs.com/testimonials",
+    },
   },
   openGraph: {
     title: "Flashfire Reviews: Success Stories & Testimonials",

--- a/app/faq/page.tsx
+++ b/app/faq/page.tsx
@@ -13,6 +13,11 @@ export const metadata: Metadata = {
   },
   alternates: {
     canonical: "https://www.flashfirejobs.com/faq",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/faq",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/faq",
+      "x-default": "https://www.flashfirejobs.com/faq",
+    },
   },
   openGraph: {
     title: "FAQ — Flashfire Job Search Automation",

--- a/app/features/cover-letter/layout.tsx
+++ b/app/features/cover-letter/layout.tsx
@@ -1,6 +1,14 @@
 import { Metadata } from "next";
 
 export const metadata: Metadata = {
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/features/cover-letter",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/features/cover-letter",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/features/cover-letter",
+      "x-default": "https://www.flashfirejobs.com/features/cover-letter",
+    },
+  },
   twitter: {
     card: "summary_large_image",
     title: "AI Cover Letter Generator — Flashfire",

--- a/app/features/dashboard-analytics/layout.tsx
+++ b/app/features/dashboard-analytics/layout.tsx
@@ -5,6 +5,11 @@ export const metadata: Metadata = {
   description: "Use FlashFire's job search analytics dashboard to track job applications, response rates, and interview conversions. Optimize your job search with data.",
   alternates: {
     canonical: "https://www.flashfirejobs.com/features/dashboard-analytics",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/features/dashboard-analytics",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/features/dashboard-analytics",
+      "x-default": "https://www.flashfirejobs.com/features/dashboard-analytics",
+    },
   },
   twitter: {
     card: "summary_large_image",

--- a/app/features/interview-tips/layout.tsx
+++ b/app/features/interview-tips/layout.tsx
@@ -5,6 +5,11 @@ export const metadata: Metadata = {
   description: "Practice mock interviews with FlashFire's AI interview tool. Get instant feedback, improve answers, and prepare confidently for real interviews.",
   alternates: {
     canonical: "https://www.flashfirejobs.com/features/interview-tips",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/features/interview-tips",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/features/interview-tips",
+      "x-default": "https://www.flashfirejobs.com/features/interview-tips",
+    },
   },
   twitter: {
     card: "summary_large_image",

--- a/app/features/job-automation/layout.tsx
+++ b/app/features/job-automation/layout.tsx
@@ -1,6 +1,14 @@
 import { Metadata } from "next";
 
 export const metadata: Metadata = {
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/features/job-automation",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/features/job-automation",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/features/job-automation",
+      "x-default": "https://www.flashfirejobs.com/features/job-automation",
+    },
+  },
   twitter: {
     card: "summary_large_image",
     title: "AI Job Application Automation — Flashfire",

--- a/app/features/job-tracker/layout.tsx
+++ b/app/features/job-tracker/layout.tsx
@@ -1,0 +1,16 @@
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/features/job-tracker",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/features/job-tracker",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/features/job-tracker",
+      "x-default": "https://www.flashfirejobs.com/features/job-tracker",
+    },
+  },
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/app/features/linkedin-profile-optimization/layout.tsx
+++ b/app/features/linkedin-profile-optimization/layout.tsx
@@ -5,6 +5,11 @@ export const metadata: Metadata = {
   description: "FlashFire offers LinkedIn profile optimization services to help job seekers rank higher in recruiter searches and improve their LinkedIn profile ranking.",
   alternates: {
     canonical: "https://www.flashfirejobs.com/features/linkedin-profile-optimization",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/features/linkedin-profile-optimization",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/features/linkedin-profile-optimization",
+      "x-default": "https://www.flashfirejobs.com/features/linkedin-profile-optimization",
+    },
   },
   twitter: {
     card: "summary_large_image",

--- a/app/features/page.tsx
+++ b/app/features/page.tsx
@@ -9,6 +9,11 @@ export const metadata: Metadata = {
     "Flashfire offers AI-powered job search and job search automation to apply smarter, optimize resumes, and get interview calls faster.",
   alternates: {
     canonical: "https://www.flashfirejobs.com/features",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/features",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/features",
+      "x-default": "https://www.flashfirejobs.com/features",
+    },
   },
   openGraph: {
     title: "AI-Powered Job Search & Job Search Automation",

--- a/app/features/precision-targeting/layout.tsx
+++ b/app/features/precision-targeting/layout.tsx
@@ -1,0 +1,16 @@
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/features/precision-targeting",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/features/precision-targeting",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/features/precision-targeting",
+      "x-default": "https://www.flashfirejobs.com/features/precision-targeting",
+    },
+  },
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/app/features/resume-optimizer/layout.tsx
+++ b/app/features/resume-optimizer/layout.tsx
@@ -1,0 +1,16 @@
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/features/resume-optimizer",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/features/resume-optimizer",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/features/resume-optimizer",
+      "x-default": "https://www.flashfirejobs.com/features/resume-optimizer",
+    },
+  },
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/app/get-me-interview/layout.tsx
+++ b/app/get-me-interview/layout.tsx
@@ -1,0 +1,16 @@
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/get-me-interview",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/get-me-interview",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/get-me-interview",
+      "x-default": "https://www.flashfirejobs.com/get-me-interview",
+    },
+  },
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/app/how-flashfire-ai-job-automation-platform-works/page.tsx
+++ b/app/how-flashfire-ai-job-automation-platform-works/page.tsx
@@ -11,6 +11,11 @@ export const metadata: Metadata = {
   },
   alternates: {
     canonical: "https://www.flashfirejobs.com/how-flashfire-ai-job-automation-platform-works",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/how-flashfire-ai-job-automation-platform-works",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/how-flashfire-ai-job-automation-platform-works",
+      "x-default": "https://www.flashfirejobs.com/how-flashfire-ai-job-automation-platform-works",
+    },
   },
   openGraph: {
     title: "AI Job Application Software to Apply for Jobs Automatically",

--- a/app/image-testimonials/page.tsx
+++ b/app/image-testimonials/page.tsx
@@ -13,6 +13,11 @@ export const metadata: Metadata = {
   },
   alternates: {
     canonical: "https://www.flashfirejobs.com/image-testimonials",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/image-testimonials",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/image-testimonials",
+      "x-default": "https://www.flashfirejobs.com/image-testimonials",
+    },
   },
   openGraph: {
     title: "Success Stories & Testimonials | Flashfire",

--- a/app/job-search/page.tsx
+++ b/app/job-search/page.tsx
@@ -13,6 +13,11 @@ export const metadata: Metadata = {
   },
   alternates: {
     canonical: "https://www.flashfirejobs.com/job-search",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/job-search",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/job-search",
+      "x-default": "https://www.flashfirejobs.com/job-search",
+    },
   },
   openGraph: {
     title: "AI Job Search — Apply Faster With Flashfire",

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -152,40 +152,26 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           href="https://api.fontshare.com/v2/css?f[]=satoshi@500&display=swap"
           rel="stylesheet"
         />
-        {/* DNS prefetch and preconnect for Calendly */}
-        <link rel="dns-prefetch" href="https://calendly.com" />
+        {/* Calendly — non-blocking CSS load (print-trick swap). The sync stylesheet was the largest render-blocking request (~1,200ms) per PageSpeed Insights. */}
         <link rel="dns-prefetch" href="https://assets.calendly.com" />
         <link
-          rel="preconnect"
-          href="https://calendly.com"
-          crossOrigin="anonymous"
-        />
-        <link
-          rel="preconnect"
-          href="https://assets.calendly.com"
-          crossOrigin="anonymous"
-        />
-        <link
           rel="preload"
-          href="https://assets.calendly.com/assets/external/widget.css"
           as="style"
-        />
-        <link
-          rel="stylesheet"
           href="https://assets.calendly.com/assets/external/widget.css"
         />
-        <link
-          rel="preload"
-          href="https://assets.calendly.com/assets/external/widget.js"
-          as="script"
+        <noscript>
+          <link
+            rel="stylesheet"
+            href="https://assets.calendly.com/assets/external/widget.css"
+          />
+        </noscript>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(function(){var l=document.createElement('link');l.rel='stylesheet';l.href='https://assets.calendly.com/assets/external/widget.css';l.media='print';l.onload=function(){l.media='all'};document.head.appendChild(l);})();`,
+          }}
         />
-        {/* DNS prefetch and preconnect for Cloudinary (blog images) */}
+        {/* Cloudinary (blog images) — dns-prefetch only; preconnect was warned as unused on PSI */}
         <link rel="dns-prefetch" href="https://res.cloudinary.com" />
-        <link
-          rel="preconnect"
-          href="https://res.cloudinary.com"
-          crossOrigin="anonymous"
-        />
       </head>
       <body
         suppressHydrationWarning
@@ -295,10 +281,10 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             `,
           }}
         />
-        {/* Calendly Script - Load early for instant booking modal */}
+        {/* Calendly Script - lazyOnload so it does not compete with LCP. Booking modal opens on user click, so a small delay is acceptable. */}
         <Script
           src="https://assets.calendly.com/assets/external/widget.js"
-          strategy="afterInteractive"
+          strategy="lazyOnload"
         />
       </body>
     </html>

--- a/app/offer-and-salary-negotiation-advisor/layout.tsx
+++ b/app/offer-and-salary-negotiation-advisor/layout.tsx
@@ -1,6 +1,14 @@
 import { Metadata } from "next";
 
 export const metadata: Metadata = {
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/offer-and-salary-negotiation-advisor",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/offer-and-salary-negotiation-advisor",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/offer-and-salary",
+      "x-default": "https://www.flashfirejobs.com/offer-and-salary-negotiation-advisor",
+    },
+  },
   twitter: {
     card: "summary_large_image",
     title: "Offer & Salary Negotiation Advisor — Flashfire",

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -12,6 +12,11 @@ export const metadata: Metadata = {
   },
   alternates: {
     canonical: "https://www.flashfirejobs.com/",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/",
+      "en-CA": "https://www.flashfirejobs.com/en-ca",
+      "x-default": "https://www.flashfirejobs.com/",
+    },
   },
   openGraph: {
     title: "Flashfire: Automate Job Applications with AI",
@@ -59,74 +64,82 @@ export default function Home() {
     "mainEntity": [
       {
         "@type": "Question",
-        "name": "What would the costs be, and are there any extra fees?",
+        "name": "Why are we the best job hunting site to find opportunities quickly?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "You pay once up front, and the charges depend on the plan you choose. There are no hidden charges, and you get all the functions in your plan (resume optimization, job applications, LinkedIn help, and interview support)."
+          "text": "Because we don't just show jobs — we apply to them for you. You skip browsing, resume editing, and forms. We do it all."
         }
       },
       {
         "@type": "Question",
-        "name": "If I am not satisfied with the service, do I get a refund?",
+        "name": "How does an AI-powered job search improve my chances of finding relevant positions?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Our priority is to ensure your satisfaction. If your expectations are not met, we additionally apply to 150-200 more jobs on your behalf; however, initiating a refund is not possible. Nonetheless, we ensure you get the maximum benefit from the service you have chosen."
+          "text": "AI-powered job search uses intelligent matching, resume optimization, and automation to apply only to roles that fit your profile. Flashfire's AI-powered job search ensures higher relevance and better recruiter response rates."
         }
       },
       {
         "@type": "Question",
-        "name": "What if I don't get any calls for interviews?",
+        "name": "Can AI job application tools help me apply for jobs faster?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "We will send 100 more applications and give you a free resume upgrade if you don't get any interview calls by the end of your plan. Only people who have signed up for our Premium Plan will be applicable for this. Your career is important to us, and we will help you every step of the way."
+          "text": "Yes. Job search automation allows AI to apply for jobs automatically on your behalf, saving time while increasing application volume and accuracy."
         }
       },
       {
         "@type": "Question",
-        "name": "Why should I consider Flashfire, when I can apply on my own?",
+        "name": "What are the benefits of using AI for job search on FlashFireJobs?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Flashfire automates your entire job search process. A team applies to 1200+ high-matching jobs in just 5-6 weeks on your behalf, and your resume is optimized for each role, so you can just focus on interviews and skills building. You will save 200 hours with us and double your callback rates."
+          "text": "Using AI for job search on FlashFireJobs offers several benefits, including personalized job recommendations, faster applications, and improved recruiter visibility. As an AI-powered job search platform, FlashFireJobs combines intelligent job discovery, AI resume matching, and automated applications to help modern job seekers find opportunities quickly and apply with confidence."
         }
       },
       {
         "@type": "Question",
-        "name": "How successful is Flashfire at securing job placements?",
+        "name": "Does FlashFireJobs act as an AI job board?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "More than 90% of the people who use Flashfire will get interview calls within the first four weeks. Most people get interviews faster than they thought they would with targeted applications and optimized resumes. Premium users get even better results."
+          "text": "Flashfire works as an AI job search platform, combining job discovery, AI job matching, and automated applications."
         }
       },
       {
         "@type": "Question",
-        "name": "How does Flashfire differ from any other job portal?",
+        "name": "How does an AI-powered job search differ from traditional job searching?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "We don't wait for you to apply like most job boards do. Instead, we apply for you every day. Our AI and human experts make each resume unique and keep track of all the submissions in your dashboard. No spam, no guessing, just results."
+          "text": "Traditional job searching is manual and time-consuming. AI-powered job search automates resume matching, job applications, and tracking, making job search automation faster and more effective."
         }
       },
       {
         "@type": "Question",
-        "name": "How will I track my job applications and progress?",
+        "name": "What is a job search virtual assistant and how can it make job hunting easier?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "You will be given credentials to your personalized dashboard where you can track your progress along with that a dedicated WhatsApp group of 3-4 people is created just for you. You will be kept updated throughout the process."
+          "text": "FlashFireJobs acts as your virtual assistant and team — finding jobs, optimizing your resume, and applying for you every day."
         }
       },
       {
         "@type": "Question",
-        "name": "Is Flashfire a good choice for students and job seekers in the U.S.?",
+        "name": "Can FlashFireJobs auto apply to jobs on my behalf?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Of course. Flashfire is made for people with OPT, CPT, or H1B visas and international students. We know that every application is important, and our team makes sure you have the best chance of getting hired in the U.S. job market."
+          "text": "Yes. Flashfire is an AI job application platform that can auto-apply to jobs using AI-driven resume matching and role-specific optimization."
         }
       },
       {
         "@type": "Question",
-        "name": "How many job applications will be applied for per day?",
+        "name": "What job application assistance features does FlashFireJobs offer?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "It depends on the number of relevant openings, but our team applies to 30 jobs each day to ensure efficiency and quality."
+          "text": "✔️ Resume optimization ✔️ Cover letter submission ✔️ 1,200+ manual applications ✔️ LinkedIn profile tips ✔️ Live job tracker ✔️ WhatsApp support ✔️ Weekly progress updates"
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Which is the best app to find job opportunities in my field?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "FlashFireJobs is ideal if you want results. We don't show jobs — we apply to them with tailored resumes and real human effort."
         }
       }
     ]

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -11,6 +11,11 @@ export const metadata: Metadata = {
   },
   alternates: {
     canonical: "https://www.flashfirejobs.com/pricing",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/pricing",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/pricing",
+      "x-default": "https://www.flashfirejobs.com/pricing",
+    },
   },
   openGraph: {
     title: "Pricing - Affordable Job Search Automation Plans",

--- a/app/recent-job-openings/page.tsx
+++ b/app/recent-job-openings/page.tsx
@@ -11,6 +11,11 @@ export const metadata: Metadata = {
     },
     alternates: {
         canonical: "https://www.flashfirejobs.com/recent-job-openings",
+        languages: {
+            "en-US": "https://www.flashfirejobs.com/recent-job-openings",
+            "en-CA": "https://www.flashfirejobs.com/en-ca/recent-job-openings",
+            "x-default": "https://www.flashfirejobs.com/recent-job-openings",
+        },
     },
     openGraph: {
         title: "AI Job Search Assistant & Job Application Automation Tool",

--- a/app/see-flashfire-in-action/page.tsx
+++ b/app/see-flashfire-in-action/page.tsx
@@ -12,6 +12,11 @@ export const metadata: Metadata = {
   },
   alternates: {
     canonical: "https://www.flashfirejobs.com/see-flashfire-in-action",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/see-flashfire-in-action",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/see-flashfire-in-action",
+      "x-default": "https://www.flashfirejobs.com/see-flashfire-in-action",
+    },
   },
   openGraph: {
     title: "See Flashfire in Action - Live Demo & Product Tour",

--- a/app/testimonials/page.tsx
+++ b/app/testimonials/page.tsx
@@ -14,6 +14,11 @@ export const metadata: Metadata = {
   },
   alternates: {
     canonical: "https://www.flashfirejobs.com/testimonials",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/testimonials",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/testimonials",
+      "x-default": "https://www.flashfirejobs.com/testimonials",
+    },
   },
   openGraph: {
     title: "Success Stories & Testimonials | Flashfire",


### PR DESCRIPTION
- Add hreflang en-US / en-CA / x-default to all paired US/CA pages (homepage, pricing, faq, testimonials, blog, contact-us, employers, how-it-works, job-search, recent-job-openings, see-flashfire-in-action, AI-copilot, career-advisor, get-me-interview, offer-and-salary, /features parent + all 9 feature sub-pages)
- New layout.tsx files for client-component pages that could not export metadata directly: get-me-interview, features/resume-optimizer, features/job-tracker, features/precision-targeting
- Replace homepage FAQPage schema with finalized 10 Q&A set (matches /faq and /en-ca/faq)
- Unblock LCP on mobile: Calendly stylesheet was the largest render-blocking request (~1,200ms per PSI). Now loaded via the print-trick CSS swap so it never blocks first paint. Calendly JS demoted from afterInteractive to lazyOnload (booking modal opens on click anyway).
- Remove unused full preconnects (PSI warned "More than 4 preconnect connections were found"); kept DNS prefetch only.