### PR TITLE
feat: add 5 new blog posts and fix coverImage display for recent blogs

### DIFF
--- a/src/components/blogs/blogCard.tsx
+++ b/src/components/blogs/blogCard.tsx
@@ -15,6 +15,7 @@ type Blog = {
   readTime?: string;
   category?: string;
   image?: string;
+  coverImage?: string;
   categoryColor?: string;
   tags?: string[];
   author?: {
@@ -51,7 +52,7 @@ export default function BlogCard({ blog }: { blog: Blog }) {
         {/* === Image === */}
         <div className="w-full aspect-video overflow-hidden relative bg-[#f9f9f9] max-[768px]:aspect-[16/10]">
           <CachedBlogImage
-            src={blog.image || ""}
+            src={blog.image || blog.coverImage || ""}
             alt={blog.title}
             width={400}
             height={250}

--- a/src/components/blogs/blogsPage.tsx
+++ b/src/components/blogs/blogsPage.tsx
@@ -376,7 +376,7 @@ export default function BlogsPage({ post }: { post: BlogPost }) {
     },
     headline: post.title,
     description: post.excerpt || post.title,
-    image: post.image || "",
+    image: post.image || post.coverImage || "",
     author: {
       "@type": "Person",
       name: post.author?.name || "Arjun Sharma",
@@ -505,7 +505,7 @@ export default function BlogsPage({ post }: { post: BlogPost }) {
               {/* === HERO IMAGE === */}
               <div className={styles.imageWrapper}>
                 <CachedBlogImage
-                  src={post.image || ""}
+                  src={post.image || post.coverImage || ""}
                   alt={post.title}
                   width={1200}
                   height={630}
@@ -693,7 +693,7 @@ export default function BlogsPage({ post }: { post: BlogPost }) {
                       >
                         <div className={styles.recentPostImage}>
                           <CachedBlogImage
-                            src={recentPost.image || ""}
+                            src={recentPost.image || recentPost.coverImage || ""}
                             alt={recentPost.title}
                             width={80}
                             height={60}
@@ -728,7 +728,7 @@ export default function BlogsPage({ post }: { post: BlogPost }) {
                         >
                           <div className={styles.recentPostImage}>
                             <CachedBlogImage
-                              src={viewedPost.image || ""}
+                              src={viewedPost.image || viewedPost.coverImage || ""}
                               alt={viewedPost.title}
                               width={80}
                               height={60}
@@ -807,7 +807,7 @@ export default function BlogsPage({ post }: { post: BlogPost }) {
                     <Link href={`/blog/${relatedPost.slug}`}>
                       <div className={styles.relatedImage}>
                         <CachedBlogImage
-                          src={relatedPost.image || ""}
+                          src={relatedPost.image || relatedPost.coverImage || ""}
                           alt={relatedPost.title}
                           width={400}
                           height={250}


### PR DESCRIPTION
- Added blog posts (IDs 303–307): is-fastapply-legit, is-careerflow-legit, is-autoapplymax-legit, is-autoapplymax-worth-it, is-careerflow-worth-it
- Added coverImage and categories fields to BlogPost type in blogsData.ts
- Fixed blogCard.tsx and blogsPage.tsx to fall back to coverImage when image field is undefined (fixes broken images in related articles section)