### PR TITLE
Fix testimonials AggregateRating schema, duplicate H1s, and en-ca/abo…

### DIFF
--- a/app/en-ca/blog/page.tsx
+++ b/app/en-ca/blog/page.tsx
@@ -46,7 +46,7 @@ export default function BlogPageCA() {
     <>
       <Navbar />
       <Suspense fallback={<div style={{ padding: "6rem 2rem", textAlign: "center" }}>Loading blogs...</div>}>
-        <BlogsClient />
+        <BlogsClient heading="Career Tips & Job Advice for Canadian Job Seekers" />
       </Suspense>
       <Footer />
     </>

--- a/app/en-ca/testimonials/page.tsx
+++ b/app/en-ca/testimonials/page.tsx
@@ -44,7 +44,7 @@ export default function TestimonialsPageCA() {
   return (
     <>
       <Navbar />
-      <HappyUsersGalleryPage />
+      <HappyUsersGalleryPage heading="Real Stories from Canadian Job Seekers" />
       <Footer />
     </>
   );

--- a/app/testimonials/page.tsx
+++ b/app/testimonials/page.tsx
@@ -48,25 +48,30 @@ export const revalidate = false; // Never revalidate - page is static
 export default function TestimonialsPage() {
   const reviewSchema = {
     "@context": "https://schema.org/",
-    "@type": "Review",
-    "author": {
-      "@type": "Person",
-      "name": "Aman Guleria"
+    "@type": "Product",
+    "name": "Flashfire AI Job Search Platform",
+    "aggregateRating": {
+      "@type": "AggregateRating",
+      "ratingValue": "4.9",
+      "ratingCount": "478"
     },
-    "itemReviewed": {
-      "@type": "Product",
-      "name": "AI Job Search Platform"
-    },
-    "reviewRating": {
-      "@type": "Rating",
-      "ratingValue": "5"
-    },
-    "name": "Best AI Powered Job Searching Platform",
-    "reviewBody": "Flashfire guided me through my entire application process with precision and efficiency. The platform's comprehensive approach — from resume optimization to automated applications — made everything seamless. The real-time updates and tracking kept me informed throughout. I landed interviews at Barclays within 10 days, and the structured process made all the difference!",
-    "datePublished": "2025-05-11",
-    "publisher": {
-      "@type": "Organization",
-      "name": "FlashFire"
+    "review": {
+      "@type": "Review",
+      "author": {
+        "@type": "Person",
+        "name": "Aman Guleria"
+      },
+      "reviewRating": {
+        "@type": "Rating",
+        "ratingValue": "5"
+      },
+      "name": "Best AI Powered Job Searching Platform",
+      "reviewBody": "Flashfire guided me through my entire application process with precision and efficiency. The platform's comprehensive approach — from resume optimization to automated applications — made everything seamless. The real-time updates and tracking kept me informed throughout. I landed interviews at Barclays within 10 days, and the structured process made all the difference!",
+      "datePublished": "2025-05-11",
+      "publisher": {
+        "@type": "Organization",
+        "name": "FlashFire"
+      }
     }
   };
 
@@ -78,7 +83,7 @@ export default function TestimonialsPage() {
       />
       <TestimonialImagePreloader />
       <Navbar />
-      <HappyUsersGalleryPage />
+      <HappyUsersGalleryPage heading="All Happy User&rsquo;s Testimonials" />
       <Footer />
     </>
   );

--- a/next.config.ts
+++ b/next.config.ts
@@ -249,6 +249,11 @@ const nextConfig: NextConfig = {
         destination: "/en-ca/how-flashfire-ai-job-automation-platform-works",
         permanent: true,
       },
+      {
+        source: "/en-ca/about-us",
+        destination: "/about-us",
+        permanent: true,
+      },
     ];
   },
 };

--- a/src/components/blogs/blogsClient.tsx
+++ b/src/components/blogs/blogsClient.tsx
@@ -12,6 +12,7 @@ import { categoryToSlug, slugToCategory, tagToSlug, slugToTag } from "@/src/util
 type BlogsClientProps = {
   categorySlug?: string;
   tagSlug?: string;
+  heading?: string;
 };
 
 
@@ -116,7 +117,7 @@ function getBlogsWithTags(): BlogPostWithOptionalMeta[] {
   return blogsWithTagsCache;
 }
 
-export default function BlogsClient({ categorySlug, tagSlug }: BlogsClientProps = {}) {
+export default function BlogsClient({ categorySlug, tagSlug, heading }: BlogsClientProps = {}) {
   const searchParams = useSearchParams();
   const tagParam = searchParams.get("tag");
   const categoryParam = searchParams.get("category");
@@ -294,7 +295,7 @@ export default function BlogsClient({ categorySlug, tagSlug }: BlogsClientProps 
             ? `Blogs tagged: ${decodedTag}`
             : decodedCategory
             ? `Blogs in ${decodedCategory}`
-            : "Insights That Spark Career Growth."}
+            : heading || "Insights That Spark Career Growth."}
         </h1>
         <p>
           {decodedTag || decodedCategory ? (

--- a/src/components/homePageHappyUsers/HappyUsersGalleryPage.tsx
+++ b/src/components/homePageHappyUsers/HappyUsersGalleryPage.tsx
@@ -35,7 +35,11 @@ const videos = [
   },
 ];
 
-export default function HappyUsersGalleryPage() {
+export default function HappyUsersGalleryPage({
+  heading = "All Happy User's Testimonials",
+}: {
+  heading?: string;
+}) {
   const [selectedImageIndex, setSelectedImageIndex] = useState<number | null>(null);
   const [playingIndex, setPlayingIndex] = useState<number | null>(null);
   const [imageLoading, setImageLoading] = useState<boolean>(false);
@@ -138,7 +142,7 @@ export default function HappyUsersGalleryPage() {
       <section className="bg-[#F55E1D] py-24 px-6">
         <div className="max-w-[1200px] mx-auto text-center">
           <h1 className="mb-6 text-5xl  font-bold text-white">
-            All Happy User&rsquo;s Testimonials
+            {heading}
           </h1>
           <p className="mb-6 text-base md:text-lg text-white">
             We've helped hundreds get there — and there's absolutely no reason you won't be next.


### PR DESCRIPTION
…ut-us 404

- Restore AggregateRating schema on /testimonials for star ratings in Google search results
- Add unique H1 headings for /en-ca/testimonials and /en-ca/blog so they no longer duplicate the US page H1s
- Redirect /en-ca/about-us to /about-us to fix the 404