### PR TITLE
Fix duplicate-content SEO issues and add 3 new blog reviews

### DIFF
--- a/app/[locale]/blog/page.tsx
+++ b/app/[locale]/blog/page.tsx
@@ -21,8 +21,8 @@ export async function generateMetadata({ params }: LocaleBlogPageProps): Promise
     description:
       "Discover expert career tips, job search strategies, resume writing guides, and industry insights to accelerate your job search success.",
     robots: {
-      index: true,
-      follow: true,
+      index: false,
+      follow: false,
     },
     alternates: {
       canonical: isCanada 

--- a/app/[locale]/blogs/page.tsx
+++ b/app/[locale]/blogs/page.tsx
@@ -21,8 +21,8 @@ export async function generateMetadata({ params }: LocaleBlogsPageProps): Promis
     description:
       "Discover expert career tips, job search strategies, resume writing guides, and industry insights to accelerate your job search success.",
     robots: {
-      index: true,
-      follow: true,
+      index: false,
+      follow: false,
     },
     alternates: {
       canonical: isCanada 

--- a/app/[locale]/employers/page.tsx
+++ b/app/[locale]/employers/page.tsx
@@ -20,8 +20,8 @@ export async function generateMetadata({ params }: LocaleEmployersPageProps): Pr
     description:
       "Partner with Flashfire to access pre-screened, qualified candidates. Connect with job seekers actively applying to roles in your industry.",
     robots: {
-      index: true,
-      follow: true,
+      index: false,
+      follow: false,
     },
     alternates: {
       canonical: isCanada 

--- a/app/[locale]/faq/page.tsx
+++ b/app/[locale]/faq/page.tsx
@@ -18,8 +18,8 @@ export async function generateMetadata({ params }: LocaleFAQPageProps): Promise<
     description:
       "Find answers to common questions about Flashfire's job search automation service, pricing, how it works, and more.",
     robots: {
-      index: true,
-      follow: true,
+      index: false,
+      follow: false,
     },
     alternates: {
       canonical: isCanada 

--- a/app/[locale]/feature/page.tsx
+++ b/app/[locale]/feature/page.tsx
@@ -18,8 +18,8 @@ export async function generateMetadata({ params }: LocaleFeaturePageProps): Prom
     description:
       "Discover Flashfire's powerful features: AI-powered resume tailoring, automated job applications, real-time tracking, and more to accelerate your job search.",
     robots: {
-      index: true,
-      follow: true,
+      index: false,
+      follow: false,
     },
     alternates: {
       canonical: isCanada 

--- a/app/[locale]/payment-policy/page.tsx
+++ b/app/[locale]/payment-policy/page.tsx
@@ -20,8 +20,8 @@ export async function generateMetadata({ params }: LocalePaymentPolicyPageProps)
     description:
       "Read Flashfire's Payment Policy to understand our payment terms and billing information.",
     robots: {
-      index: true,
-      follow: true,
+      index: false,
+      follow: false,
     },
     alternates: {
       canonical: isCanada 

--- a/app/[locale]/pricing/page.tsx
+++ b/app/[locale]/pricing/page.tsx
@@ -23,8 +23,8 @@ export async function generateMetadata({ params }: LocalePricingPageProps): Prom
     description:
       "Choose the perfect Flashfire plan for your job search. Transparent pricing with flexible options to automate your job applications and save time.",
     robots: {
-      index: true,
-      follow: true,
+      index: false,
+      follow: false,
     },
     alternates: {
       canonical: isCanada 

--- a/app/[locale]/privacy-policy/page.tsx
+++ b/app/[locale]/privacy-policy/page.tsx
@@ -20,8 +20,8 @@ export async function generateMetadata({ params }: LocalePrivacyPolicyPageProps)
     description:
       "Read Flashfire's Privacy Policy to understand how we collect, use, and protect your personal information.",
     robots: {
-      index: true,
-      follow: true,
+      index: false,
+      follow: false,
     },
     alternates: {
       canonical: isCanada 

--- a/app/[locale]/refund-policy/page.tsx
+++ b/app/[locale]/refund-policy/page.tsx
@@ -20,8 +20,8 @@ export async function generateMetadata({ params }: LocaleRefundPolicyPageProps):
     description:
       "Read Flashfire's Refund Policy to understand our refund terms and conditions.",
     robots: {
-      index: true,
-      follow: true,
+      index: false,
+      follow: false,
     },
     alternates: {
       canonical: isCanada 

--- a/app/[locale]/terms-of-service/page.tsx
+++ b/app/[locale]/terms-of-service/page.tsx
@@ -20,8 +20,8 @@ export async function generateMetadata({ params }: LocaleTermsOfServicePageProps
     description:
       "Read Flashfire's Terms of Service to understand the terms and conditions for using our job search automation service.",
     robots: {
-      index: true,
-      follow: true,
+      index: false,
+      follow: false,
     },
     alternates: {
       canonical: isCanada 

--- a/app/[locale]/testimonials/page.tsx
+++ b/app/[locale]/testimonials/page.tsx
@@ -18,8 +18,8 @@ export async function generateMetadata({ params }: LocaleTestimonialsPageProps):
     description:
       "Read success stories and testimonials from job seekers who used Flashfire to land their dream jobs. See how our automated job search service helped them succeed.",
     robots: {
-      index: true,
-      follow: true,
+      index: false,
+      follow: false,
     },
     alternates: {
       canonical: isCanada 

--- a/app/en-ca/about-us/page.tsx
+++ b/app/en-ca/about-us/page.tsx
@@ -1,0 +1,59 @@
+import { Metadata } from "next";
+import AboutUs from "@/src/components/pages/aboutUs/AboutUs";
+import Footer from "@/src/components/footer/footer";
+import Navbar from "@/src/components/navbar/navbar";
+
+export const metadata: Metadata = {
+  title: "About Flashfire — AI Job Search Automation Platform (Canada)",
+  description:
+    "Flashfire is an AI job application service that automates job applications, optimizes resumes, and helps Canadian job seekers land interviews faster.",
+  robots: {
+    index: true,
+    follow: true,
+  },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-ca/about-us",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/about-us",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/about-us",
+      "x-default": "https://www.flashfirejobs.com/about-us",
+    },
+  },
+  openGraph: {
+    title: "About Flashfire — AI Job Search Automation Platform (Canada)",
+    description:
+      "Flashfire is an AI job application service that automates job applications, optimizes resumes, and helps Canadian job seekers land interviews faster.",
+    url: "https://www.flashfirejobs.com/en-ca/about-us",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "About Flashfire — AI Job Search Automation Platform (Canada)",
+    description: "Flashfire is an AI job application service that automates job applications, optimizes resumes, and helps Canadian job seekers land interviews faster.",
+    images: ["https://www.flashfirejobs.com/images/og-image.png"],
+  },
+};
+
+export default function AboutUsPageCA() {
+  const schema = {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "name": "AI Job Application Service | Job Application Automation (Canada)",
+    "url": "https://www.flashfirejobs.com/en-ca/about-us",
+    "description": "Flashfire is an AI job application service that automates job applications, optimizes resumes, and helps Canadian job seekers land interviews faster.",
+    "publisher": {
+      "@type": "Organization",
+      "name": "Flashfire",
+      "url": "https://www.flashfirejobs.com"
+    }
+  };
+
+  return (
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }} />
+      <Navbar />
+      <AboutUs />
+      <Footer />
+    </>
+  );
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -163,6 +163,11 @@ const nextConfig: NextConfig = {
         permanent: true,
       },
       {
+        source: "/en-ca/blogs",
+        destination: "/en-ca/blog",
+        permanent: true,
+      },
+      {
         source: "/feature",
         destination: "/features",
         permanent: true,
@@ -247,11 +252,6 @@ const nextConfig: NextConfig = {
       {
         source: "/en-ca/how-it-works",
         destination: "/en-ca/how-flashfire-ai-job-automation-platform-works",
-        permanent: true,
-      },
-      {
-        source: "/en-ca/about-us",
-        destination: "/about-us",
         permanent: true,
       },
     ];

--- a/src/components/employers/employerForm.tsx
+++ b/src/components/employers/employerForm.tsx
@@ -45,6 +45,29 @@ const INITIAL_FORM_DATA = {
 
 type FormData = typeof INITIAL_FORM_DATA;
 
+const employerBenefits = [
+  {
+    title: "Pre-Screened, Job-Ready Candidates",
+    description:
+      "Every candidate in our network has already gone through resume optimization and application coaching, so you're reviewing people who understand how to present their skills clearly and are actively engaged in their job search.",
+  },
+  {
+    title: "Faster Time-to-Hire",
+    description:
+      "Instead of sifting through hundreds of unqualified applicants, tell us your hiring needs and we'll help you connect with candidates whose skills, experience, and expectations already match your role.",
+  },
+  {
+    title: "Built for Startups and Growing Teams",
+    description:
+      "Whether you're hiring your first employee or scaling a full department, our process adapts to your company size, industry, and urgency — from immediate openings to roles you're planning months ahead.",
+  },
+  {
+    title: "No Long-Term Commitment Required",
+    description:
+      "Submit your hiring needs once and our team reaches out to discuss next steps. There's no obligation to sign a long-term contract before you see whether the candidates we surface are a fit.",
+  },
+];
+
 export default function EmployerForm() {
   const router = useRouter();
   const [formData, setFormData] = useState<FormData>(INITIAL_FORM_DATA);
@@ -502,6 +525,50 @@ export default function EmployerForm() {
                 </div>
               </form>
             </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Employer Content Section */}
+      <div className="bg-[#fdf7f4] px-6 py-16 lg:px-12">
+        <div className="mx-auto max-w-5xl">
+          <h2 className="mb-6 text-center text-3xl font-bold text-gray-900 lg:text-4xl">
+            Why Employers Partner With Flashfire
+          </h2>
+          <p className="mx-auto mb-12 max-w-3xl text-center text-lg leading-relaxed text-gray-600">
+            Hiring the right person shouldn't mean weeks of sorting through resumes that don't match what
+            you're actually looking for. Flashfire connects employers with candidates who have already
+            invested time in refining their resumes, clarifying their goals, and preparing for the roles
+            they want — so the people you talk to are ready for a real conversation, not a first screening.
+          </p>
+
+          <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+            {employerBenefits.map((benefit) => (
+              <div
+                key={benefit.title}
+                className="rounded-xl border-2 border-gray-100 bg-white p-6 shadow-sm"
+              >
+                <h3 className="mb-2 text-lg font-semibold text-gray-900">
+                  {benefit.title}
+                </h3>
+                <p className="text-gray-600 leading-relaxed">{benefit.description}</p>
+              </div>
+            ))}
+          </div>
+
+          <div className="mt-12 max-w-3xl mx-auto text-gray-600 leading-relaxed space-y-4">
+            <p>
+              Fill out the form above with a few details about your company and the role you're hiring for —
+              company size, industry, location, salary range, and how urgently you need to fill the position.
+              Our team reviews every submission and follows up directly to understand your hiring needs in
+              more depth before introducing you to relevant candidates.
+            </p>
+            <p>
+              We work with employers across a range of industries and company sizes, from early-stage startups
+              filling their first few roles to established companies scaling out entire teams. There's no fee
+              to submit a hiring request, and you're never obligated to move forward if the candidates we
+              introduce aren't the right fit.
+            </p>
           </div>
         </div>
       </div>

--- a/src/components/pages/jobSearch/JobSearch.tsx
+++ b/src/components/pages/jobSearch/JobSearch.tsx
@@ -35,8 +35,36 @@ const steps = [
 
 const benefits = [
   "Flashfire scans job listings near your location",
-  "Our team applies to matched roles for you", 
+  "Our team applies to matched roles for you",
   "You get updates without lifting a finger"
+];
+
+const jobSearchFaqs = [
+  {
+    question: "How is Flashfire different from a normal job search?",
+    answer:
+      "A normal job search means hours spent scrolling through job boards, retyping the same details into dozens of application forms, and losing track of which roles you've already applied to. Flashfire replaces that manual grind with a dedicated team that searches, filters, and applies to matching roles on your behalf, so your time goes into interview prep instead of data entry.",
+  },
+  {
+    question: "Do real people apply to jobs, or is it fully automated?",
+    answer:
+      "It's human-powered automation. A trained team of 4-5 specialists reviews each opening, checks it against your goals, skills, visa status, and salary expectations, and submits a tailored application. Software helps us scan listings faster, but a person makes the final call on every submission.",
+  },
+  {
+    question: "What information does Flashfire use to find matching jobs?",
+    answer:
+      "We start with your target roles, preferred locations, salary range, work authorization status, and core skills. From there, we continuously scan job listings across company career pages and major job boards, filtering out roles that don't fit so you only see progress on opportunities that actually match your profile.",
+  },
+  {
+    question: "How will I know which jobs have been applied to?",
+    answer:
+      "Every application is logged and visible from your dashboard in real time. You'll see the company, role, and application status without having to ask for updates or dig through your inbox for confirmation emails.",
+  },
+  {
+    question: "Is this job search service suitable for career changers and recent graduates?",
+    answer:
+      "Yes. Whether you're pivoting industries, graduating and applying for your first full-time role, or a working professional looking for your next step, the underlying process is the same: define your goals, let the team find and apply to matching roles, and review progress from one place instead of managing it all yourself.",
+  },
 ];
 
 export default function JobSearch() {
@@ -312,6 +340,55 @@ export default function JobSearch() {
 
   </div>
 </section>
+
+      {/* Why Choose Flashfire Section */}
+      <section className="py-16 sm:py-20 px-4 sm:px-6 lg:px-8">
+        <div className="max-w-4xl mx-auto">
+          <h2 className="text-3xl sm:text-4xl font-bold text-black mb-6 text-center">
+            Why Job Seekers Choose Flashfire
+          </h2>
+          <div className="space-y-4 text-black/70 text-lg leading-relaxed">
+            <p>
+              Searching for a job while working full-time, studying, or managing a career transition is exhausting.
+              Most job seekers spend more time filling out repetitive application forms than actually preparing for
+              interviews. Flashfire was built to fix that imbalance by taking the manual, repetitive part of the
+              job search off your plate.
+            </p>
+            <p>
+              Instead of relying on generic keyword matching, our team looks at your specific goals — the roles
+              you want, the industries you're targeting, your location preferences, and your visa or work
+              authorization status — before applying to a single job. That means the applications going out under
+              your name are relevant, not just high in volume.
+            </p>
+            <p>
+              This approach works well for people who already know what they want but don't have the bandwidth to
+              apply consistently, as well as for people who are new to the job market and unsure where to start.
+              Either way, you keep full visibility into every application through your dashboard, so you're never
+              left wondering what's happening with your job search.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* FAQ Section */}
+      <section className="py-16 sm:py-20 px-4 sm:px-6 lg:px-8 bg-[#fff7f2]">
+        <div className="max-w-4xl mx-auto">
+          <h2 className="text-3xl sm:text-4xl font-bold text-black mb-10 text-center">
+            Frequently Asked Questions
+          </h2>
+          <div className="space-y-6">
+            {jobSearchFaqs.map((faq, index) => (
+              <div
+                key={index}
+                className="bg-white rounded-2xl p-6 shadow-sm border border-[#ff4c00]/10"
+              >
+                <h3 className="text-lg font-bold text-black mb-2">{faq.question}</h3>
+                <p className="text-black/70 leading-relaxed">{faq.answer}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
 
       {/* CTA Section */}
       <section className="py-16 sm:py-20 px-4 sm:px-6 lg:px-8">


### PR DESCRIPTION
## Summary
- Set `index: false` on 11 `app/[locale]/*` wildcard pages (blog, blogs, testimonials, employers, faq, feature, pricing, payment-policy, privacy-policy, refund-policy, terms-of-service). This route has no `generateStaticParams`, so any string in the locale segment rendered a live, indexable duplicate of the page — same H1, same content — which was fragmenting rankings and causing Google to report duplicate H1 tags.
- Added an `/en-ca/blogs` → `/en-ca/blog` redirect to eliminate a second duplicate route.
- Replaced the `/en-ca/about-us` → `/about-us` redirect with a dedicated Canada `about-us` page (own metadata, canonical, JSON-LD schema) instead of bouncing Canadian visitors/crawlers to the US page.
- Expanded thin content on `/job-search` (was ~361 words) and `/employers` (was ~269 words) with real body copy and FAQ sections.
- Added 3 new blog reviews to `blogsData.ts`: Huntr, LoopCV, and AiApply (`is-huntr-legit`, `is-loopcv-legit`, `is-aiapply-legit`), following the existing blog entry format.

## Test plan
- [ ] Run `npm install && npm run build` locally to confirm a clean production build
- [ ] Spot-check `/en-ca/about-us` renders correctly with correct canonical/meta tags
- [ ] Spot-check `/job-search` and `/employers` render the new content sections without layout issues
- [ ] Confirm `/blog/is-huntr-legit`, `/blog/is-loopcv-legit`, `/blog/is-aiapply-legit` render correctly
- [ ] Confirm `/en-ca/blogs` redirects to `/en-ca/blog`
- [ ] Verify `app/[locale]/*` pages still render (just non-indexable) for any legitimate `en-ca`/default locale traffic