### PR TITLE
Fix 404s on en-ca routes for feature and calculator/tool pages

### DIFF
--- a/app/en-ca/after-tax-income-calculator/page.tsx
+++ b/app/en-ca/after-tax-income-calculator/page.tsx
@@ -1,0 +1,24 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/after-tax-income-calculator/page";
+
+export const metadata: Metadata = {
+  title: "After Tax Income Calculator – Net Annual Income | Flashfire Canada",
+  description: "Estimate your after-tax income by filing status, deductions, tax credits, and provincial tax rate.",
+  robots: { index: true, follow: true },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-ca/after-tax-income-calculator",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/after-tax-income-calculator",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/after-tax-income-calculator",
+      "x-default": "https://www.flashfirejobs.com/after-tax-income-calculator",
+    },
+  },
+  openGraph: {
+    title: "After Tax Income Calculator – Net Annual Income | Flashfire Canada",
+    description: "Estimate your after-tax income by filing status, deductions, tax credits, and provincial tax rate.",
+    url: "https://www.flashfirejobs.com/en-ca/after-tax-income-calculator",
+    type: "website",
+  },
+  twitter: { card: "summary_large_image", images: ["https://www.flashfirejobs.com/images/og-image.png"] },
+};

--- a/app/en-ca/ai-career-assessment-skill-gap-analysis/page.tsx
+++ b/app/en-ca/ai-career-assessment-skill-gap-analysis/page.tsx
@@ -1,0 +1,18 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/ai-career-assessment-skill-gap-analysis/page";
+
+export const metadata: Metadata = {
+  title: "AI Career Assessment & Skill Gap Analysis Tool | Flashfire Canada",
+  description:
+    "Run an AI-powered career assessment and skill gap analysis to understand your strengths, weaknesses, and best-fit roles in the Canadian job market.",
+  robots: { index: true, follow: true },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-ca/ai-career-assessment-skill-gap-analysis",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/ai-career-assessment-skill-gap-analysis",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/ai-career-assessment-skill-gap-analysis",
+      "x-default": "https://www.flashfirejobs.com/ai-career-assessment-skill-gap-analysis",
+    },
+  },
+};

--- a/app/en-ca/ai-follow-up-email-generator/page.tsx
+++ b/app/en-ca/ai-follow-up-email-generator/page.tsx
@@ -1,0 +1,18 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/ai-follow-up-email-generator/page";
+
+export const metadata: Metadata = {
+  title: "AI Follow-Up Email Generator for Job Applications | Flashfire Canada",
+  description:
+    "Generate professional, timely follow-up emails for job applications and interviews using Flashfire's AI follow-up email generator.",
+  robots: { index: true, follow: true },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-ca/ai-follow-up-email-generator",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/ai-follow-up-email-generator",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/ai-follow-up-email-generator",
+      "x-default": "https://www.flashfirejobs.com/ai-follow-up-email-generator",
+    },
+  },
+};

--- a/app/en-ca/ai-interview-answer-generator/page.tsx
+++ b/app/en-ca/ai-interview-answer-generator/page.tsx
@@ -1,0 +1,24 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/ai-interview-answer-generator/page";
+
+export const metadata: Metadata = {
+  title: "AI Interview Answer Generator – STAR Format | Flashfire Canada",
+  description: "Generate polished STAR-format interview answers from your role, question, and achievement. Personalize and ace your next interview.",
+  robots: { index: true, follow: true },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-ca/ai-interview-answer-generator",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/ai-interview-answer-generator",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/ai-interview-answer-generator",
+      "x-default": "https://www.flashfirejobs.com/ai-interview-answer-generator",
+    },
+  },
+  openGraph: {
+    title: "AI Interview Answer Generator – STAR Format | Flashfire Canada",
+    description: "Generate polished STAR-format interview answers from your role, question, and achievement. Personalize and ace your next interview.",
+    url: "https://www.flashfirejobs.com/en-ca/ai-interview-answer-generator",
+    type: "website",
+  },
+  twitter: { card: "summary_large_image", images: ["https://www.flashfirejobs.com/images/og-image.png"] },
+};

--- a/app/en-ca/ai-job-alerts/page.tsx
+++ b/app/en-ca/ai-job-alerts/page.tsx
@@ -1,0 +1,18 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/ai-job-alerts/page";
+
+export const metadata: Metadata = {
+  title: "AI Job Alerts & Smart Job Notifications | Flashfire Canada",
+  description:
+    "Get AI-powered job alerts and smart notifications so you never miss high-fit roles that match your profile in Canada.",
+  robots: { index: true, follow: true },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-ca/ai-job-alerts",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/ai-job-alerts",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/ai-job-alerts",
+      "x-default": "https://www.flashfirejobs.com/ai-job-alerts",
+    },
+  },
+};

--- a/app/en-ca/ai-job-matching-platform/page.tsx
+++ b/app/en-ca/ai-job-matching-platform/page.tsx
@@ -1,0 +1,18 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/ai-job-matching-platform/page";
+
+export const metadata: Metadata = {
+  title: "AI Job Matching Platform | Flashfire Canada",
+  description:
+    "Flashfire's AI job matching platform connects your skills, experience, and goals with the right roles across the Canadian market.",
+  robots: { index: true, follow: true },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-ca/ai-job-matching-platform",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/ai-job-matching-platform",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/ai-job-matching-platform",
+      "x-default": "https://www.flashfirejobs.com/ai-job-matching-platform",
+    },
+  },
+};

--- a/app/en-ca/ai-job-search-platform-for-freshers/page.tsx
+++ b/app/en-ca/ai-job-search-platform-for-freshers/page.tsx
@@ -1,0 +1,24 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/ai-job-search-platform-for-freshers/page";
+
+export const metadata: Metadata = {
+  title: "AI Job Search Platform for Freshers | Flashfire Canada",
+  description:
+    "Use Flashfire's AI job search platform for freshers to discover internships and entry-level roles that match your skills and goals in Canada.",
+  robots: { index: true, follow: true },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-ca/ai-job-search-platform-for-freshers",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/ai-job-search-platform-for-freshers",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/ai-job-search-platform-for-freshers",
+      "x-default": "https://www.flashfirejobs.com/ai-job-search-platform-for-freshers",
+    },
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "AI Job Search Platform for Freshers — Flashfire Canada",
+    description: "Fresh graduate? Flashfire automates your job search so you can apply to hundreds of roles with optimized resumes and get interviews faster.",
+    images: ["https://www.flashfirejobs.com/images/og-image.png"],
+  },
+};

--- a/app/en-ca/ai-remote-job-search-platform/page.tsx
+++ b/app/en-ca/ai-remote-job-search-platform/page.tsx
@@ -1,0 +1,18 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/ai-remote-job-search-platform/page";
+
+export const metadata: Metadata = {
+  title: "AI Remote Job Search Platform | Flashfire Canada",
+  description:
+    "Discover remote jobs across Canada, US, and global markets with Flashfire's AI-powered remote job search platform.",
+  robots: { index: true, follow: true },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-ca/ai-remote-job-search-platform",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/ai-remote-job-search-platform",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/ai-remote-job-search-platform",
+      "x-default": "https://www.flashfirejobs.com/ai-remote-job-search-platform",
+    },
+  },
+};

--- a/app/en-ca/ai-resume-builder/page.tsx
+++ b/app/en-ca/ai-resume-builder/page.tsx
@@ -1,0 +1,18 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/ai-resume-builder/page";
+
+export const metadata: Metadata = {
+  title: "AI Resume Builder for Job Seekers | Flashfire Canada",
+  description:
+    "Use Flashfire's AI resume builder to create ATS-friendly, professional resumes tailored to every job you apply for in Canada.",
+  robots: { index: true, follow: true },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-ca/ai-resume-builder",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/ai-resume-builder",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/ai-resume-builder",
+      "x-default": "https://www.flashfirejobs.com/ai-resume-builder",
+    },
+  },
+};

--- a/app/en-ca/ai-resume-summary-generator/page.tsx
+++ b/app/en-ca/ai-resume-summary-generator/page.tsx
@@ -1,0 +1,17 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/ai-resume-summary-generator/page";
+
+export const metadata: Metadata = {
+  title: "AI Resume Summary Generator | Flashfire Canada",
+  description: "Generate a compelling professional resume summary in seconds. Free AI resume summary generator.",
+  robots: { index: true, follow: true },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-ca/ai-resume-summary-generator",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/ai-resume-summary-generator",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/ai-resume-summary-generator",
+      "x-default": "https://www.flashfirejobs.com/ai-resume-summary-generator",
+    },
+  },
+};

--- a/app/en-ca/ats-score-checker/page.tsx
+++ b/app/en-ca/ats-score-checker/page.tsx
@@ -1,0 +1,30 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/ats-score-checker/page";
+
+export const metadata: Metadata = {
+  title: "Free ATS Resume Score Checker | Flashfire Canada",
+  description: "Check your resume ATS score instantly. Get detailed feedback and improvement tips. Free ATS score checker.",
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-ca/ats-score-checker",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/ats-score-checker",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/ats-score-checker",
+      "x-default": "https://www.flashfirejobs.com/ats-score-checker",
+    },
+  },
+  openGraph: {
+    title: "Free ATS Resume Score Checker | Flashfire Canada",
+    description: "Check your resume ATS score instantly. Get detailed feedback and improvement tips. Free ATS score checker.",
+    url: "https://www.flashfirejobs.com/en-ca/ats-score-checker",
+    type: "website",
+    images: [
+      {
+        url: "https://www.flashfirejobs.com/images/og-image.png",
+        width: 1200,
+        height: 630,
+        alt: "Flashfire",
+      },
+    ],
+  },
+};

--- a/app/en-ca/cv-keyword-scanner/page.tsx
+++ b/app/en-ca/cv-keyword-scanner/page.tsx
@@ -1,0 +1,16 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/cv-keyword-scanner/page";
+
+export const metadata: Metadata = {
+  title: "CV Keyword Scanner | Flashfire Canada",
+  description: "Scan your resume for missing keywords. Match your CV to job descriptions. Free CV keyword scanner.",
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-ca/cv-keyword-scanner",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/cv-keyword-scanner",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/cv-keyword-scanner",
+      "x-default": "https://www.flashfirejobs.com/cv-keyword-scanner",
+    },
+  },
+};

--- a/app/en-ca/features/ai-cover-letter-generator/page.tsx
+++ b/app/en-ca/features/ai-cover-letter-generator/page.tsx
@@ -1,0 +1,40 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/features/ai-cover-letter-generator/page";
+
+export const metadata: Metadata = {
+  title: "AI Cover Letter Builder for ATS-Friendly Job Applications | Flashfire Canada",
+  description:
+    "Flashfire's AI cover letter builder helps Canadian job seekers generate job-specific, ATS-friendly cover letters in minutes using AI-powered customization.",
+  robots: {
+    index: true,
+    follow: true,
+  },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-ca/features/ai-cover-letter-generator",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/features/ai-cover-letter-generator",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/features/ai-cover-letter-generator",
+      "x-default": "https://www.flashfirejobs.com/features/ai-cover-letter-generator",
+    },
+  },
+  openGraph: {
+    title: "AI Cover Letter Builder for ATS-Friendly Job Applications | Flashfire Canada",
+    description:
+      "Generate job-specific, ATS-friendly cover letters in minutes with Flashfire's AI-powered customization, built for Canadian job seekers.",
+    url: "https://www.flashfirejobs.com/en-ca/features/ai-cover-letter-generator",
+    type: "website",
+    images: [
+      {
+        url: "https://www.flashfirejobs.com/images/og-image.png",
+        width: 1200,
+        height: 630,
+        alt: "FLASHFIRE Logo",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    images: ["https://www.flashfirejobs.com/images/og-image.png"],
+  },
+};

--- a/app/en-ca/features/ai-job-targeting/page.tsx
+++ b/app/en-ca/features/ai-job-targeting/page.tsx
@@ -1,0 +1,40 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/features/ai-job-targeting/page";
+
+export const metadata: Metadata = {
+  title: "AI Precision Job Targeting for Faster Interview Calls | Flashfire Canada",
+  description:
+    "Apply to jobs that actually match your profile. FlashFire's AI targets jobs where your skills, experience, and ATS score give Canadian job seekers the highest chance of interviews.",
+  robots: {
+    index: true,
+    follow: true,
+  },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-ca/features/ai-job-targeting",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/features/ai-job-targeting",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/features/ai-job-targeting",
+      "x-default": "https://www.flashfirejobs.com/features/ai-job-targeting",
+    },
+  },
+  openGraph: {
+    title: "AI Precision Job Targeting for Faster Interview Calls | Flashfire Canada",
+    description:
+      "FlashFire's AI targets jobs where your skills, experience, and ATS score give you the highest chance of interviews in Canada.",
+    url: "https://www.flashfirejobs.com/en-ca/features/ai-job-targeting",
+    type: "website",
+    images: [
+      {
+        url: "https://www.flashfirejobs.com/images/og-image.png",
+        width: 1200,
+        height: 630,
+        alt: "FLASHFIRE Logo",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    images: ["https://www.flashfirejobs.com/images/og-image.png"],
+  },
+};

--- a/app/en-ca/features/automated-job-applications/page.tsx
+++ b/app/en-ca/features/automated-job-applications/page.tsx
@@ -1,0 +1,40 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/features/automated-job-applications/page";
+
+export const metadata: Metadata = {
+  title: "Job Application Automation Tool | AI Job Applications | Flashfire Canada",
+  description:
+    "Flashfire is an AI job application automation tool that helps Canadian job seekers automate job applications, beat ATS filters, and land interviews faster.",
+  robots: {
+    index: true,
+    follow: true,
+  },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-ca/features/automated-job-applications",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/features/automated-job-applications",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/features/automated-job-applications",
+      "x-default": "https://www.flashfirejobs.com/features/automated-job-applications",
+    },
+  },
+  openGraph: {
+    title: "Job Application Automation Tool | AI Job Applications | Flashfire Canada",
+    description:
+      "Automate job applications, beat ATS filters, and land interviews faster with Flashfire's AI job application automation tool.",
+    url: "https://www.flashfirejobs.com/en-ca/features/automated-job-applications",
+    type: "website",
+    images: [
+      {
+        url: "https://www.flashfirejobs.com/images/og-image.png",
+        width: 1200,
+        height: 630,
+        alt: "FLASHFIRE Logo",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    images: ["https://www.flashfirejobs.com/images/og-image.png"],
+  },
+};

--- a/app/en-ca/features/job-application-tracker/page.tsx
+++ b/app/en-ca/features/job-application-tracker/page.tsx
@@ -1,0 +1,40 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/features/job-application-tracker/page";
+
+export const metadata: Metadata = {
+  title: "Job Application Tracker to Track Job Applications | Flashfire Canada",
+  description:
+    "Track job applications in one place with FlashFire's job application tracker. Organize jobs, monitor interviews, and optimize your Canadian job search faster.",
+  robots: {
+    index: true,
+    follow: true,
+  },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-ca/features/job-application-tracker",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/features/job-application-tracker",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/features/job-application-tracker",
+      "x-default": "https://www.flashfirejobs.com/features/job-application-tracker",
+    },
+  },
+  openGraph: {
+    title: "Job Application Tracker to Track Job Applications | Flashfire Canada",
+    description:
+      "Organize jobs, monitor interviews, and optimize your job search faster with FlashFire's job application tracker.",
+    url: "https://www.flashfirejobs.com/en-ca/features/job-application-tracker",
+    type: "website",
+    images: [
+      {
+        url: "https://www.flashfirejobs.com/images/og-image.png",
+        width: 1200,
+        height: 630,
+        alt: "FLASHFIRE Logo",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    images: ["https://www.flashfirejobs.com/images/og-image.png"],
+  },
+};

--- a/app/en-ca/features/linkedin-profile-optimization-tool/page.tsx
+++ b/app/en-ca/features/linkedin-profile-optimization-tool/page.tsx
@@ -1,0 +1,40 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/features/linkedin-profile-optimization-tool/page";
+
+export const metadata: Metadata = {
+  title: "LinkedIn Profile Optimization for Recruiter Visibility | Flashfire Canada",
+  description:
+    "Optimize your LinkedIn profile to boost recruiter visibility. FlashFire optimizes your LinkedIn to rank higher in recruiter searches and get more interview messages in Canada.",
+  robots: {
+    index: true,
+    follow: true,
+  },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-ca/features/linkedin-profile-optimization-tool",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/features/linkedin-profile-optimization-tool",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/features/linkedin-profile-optimization-tool",
+      "x-default": "https://www.flashfirejobs.com/features/linkedin-profile-optimization-tool",
+    },
+  },
+  openGraph: {
+    title: "LinkedIn Profile Optimization for Recruiter Visibility | Flashfire Canada",
+    description:
+      "Rank higher in recruiter searches and get more interview messages with Flashfire's LinkedIn profile optimization.",
+    url: "https://www.flashfirejobs.com/en-ca/features/linkedin-profile-optimization-tool",
+    type: "website",
+    images: [
+      {
+        url: "https://www.flashfirejobs.com/images/og-image.png",
+        width: 1200,
+        height: 630,
+        alt: "FLASHFIRE Logo",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    images: ["https://www.flashfirejobs.com/images/og-image.png"],
+  },
+};

--- a/app/en-ca/gross-pay-calculator/page.tsx
+++ b/app/en-ca/gross-pay-calculator/page.tsx
@@ -1,0 +1,24 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/gross-pay-calculator/page";
+
+export const metadata: Metadata = {
+  title: "Gross Pay Calculator – Weekly, Monthly & Annual | Flashfire Canada",
+  description: "Calculate gross pay before taxes from hourly rate, regular hours, overtime, and annual bonus.",
+  robots: { index: true, follow: true },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-ca/gross-pay-calculator",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/gross-pay-calculator",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/gross-pay-calculator",
+      "x-default": "https://www.flashfirejobs.com/gross-pay-calculator",
+    },
+  },
+  openGraph: {
+    title: "Gross Pay Calculator – Weekly, Monthly & Annual | Flashfire Canada",
+    description: "Calculate gross pay before taxes from hourly rate, regular hours, overtime, and annual bonus.",
+    url: "https://www.flashfirejobs.com/en-ca/gross-pay-calculator",
+    type: "website",
+  },
+  twitter: { card: "summary_large_image", images: ["https://www.flashfirejobs.com/images/og-image.png"] },
+};

--- a/app/en-ca/hourly-to-salary-calculator/page.tsx
+++ b/app/en-ca/hourly-to-salary-calculator/page.tsx
@@ -1,0 +1,24 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/hourly-to-salary-calculator/page";
+
+export const metadata: Metadata = {
+  title: "Hourly to Salary Calculator – Convert Hourly Pay | Flashfire Canada",
+  description: "Convert your hourly wage to annual salary instantly. Includes overtime and weeks-per-year inputs.",
+  robots: { index: true, follow: true },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-ca/hourly-to-salary-calculator",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/hourly-to-salary-calculator",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/hourly-to-salary-calculator",
+      "x-default": "https://www.flashfirejobs.com/hourly-to-salary-calculator",
+    },
+  },
+  openGraph: {
+    title: "Hourly to Salary Calculator – Convert Hourly Pay | Flashfire Canada",
+    description: "Convert your hourly wage to annual salary instantly. Includes overtime and weeks-per-year inputs.",
+    url: "https://www.flashfirejobs.com/en-ca/hourly-to-salary-calculator",
+    type: "website",
+  },
+  twitter: { card: "summary_large_image", images: ["https://www.flashfirejobs.com/images/og-image.png"] },
+};

--- a/app/en-ca/interview-buddy/page.tsx
+++ b/app/en-ca/interview-buddy/page.tsx
@@ -1,0 +1,32 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/interview-buddy/page";
+
+export const metadata: Metadata = {
+  title: "AI Interview Assistant for Real-Time Support | Flashfire Canada",
+  description:
+    "Get real-time AI support during interviews with Flashfire's AI interview assistant. Receive instant answers, live transcripts, and role-specific guidance.",
+  robots: {
+    index: true,
+    follow: true,
+  },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-ca/interview-buddy",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/interview-buddy",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/interview-buddy",
+      "x-default": "https://www.flashfirejobs.com/interview-buddy",
+    },
+  },
+  openGraph: {
+    title: "AI Interview Assistant for Real-Time Support | Flashfire Canada",
+    description:
+      "Get real-time AI support during interviews with Flashfire's AI interview assistant. Receive instant answers, live transcripts, and role-specific guidance.",
+    url: "https://www.flashfirejobs.com/en-ca/interview-buddy",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    images: ["https://www.flashfirejobs.com/images/og-image.png"],
+  },
+};

--- a/app/en-ca/job-application-status-tracker/page.tsx
+++ b/app/en-ca/job-application-status-tracker/page.tsx
@@ -1,0 +1,18 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/job-application-status-tracker/page";
+
+export const metadata: Metadata = {
+  title: "Job Application Status Tracker with AI | Flashfire Canada",
+  description:
+    "Track every job application, follow-up, and interview in one AI-powered job application status tracker.",
+  robots: { index: true, follow: true },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-ca/job-application-status-tracker",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/job-application-status-tracker",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/job-application-status-tracker",
+      "x-default": "https://www.flashfirejobs.com/job-application-status-tracker",
+    },
+  },
+};

--- a/app/en-ca/resume-bullet-point-generator/page.tsx
+++ b/app/en-ca/resume-bullet-point-generator/page.tsx
@@ -1,0 +1,16 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/resume-bullet-point-generator/page";
+
+export const metadata: Metadata = {
+  title: "Resume Bullet Point Generator | Flashfire Canada",
+  description: "Turn vague job duties into sharp, ATS-friendly bullet points. Free AI resume bullet point generator.",
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-ca/resume-bullet-point-generator",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/resume-bullet-point-generator",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/resume-bullet-point-generator",
+      "x-default": "https://www.flashfirejobs.com/resume-bullet-point-generator",
+    },
+  },
+};

--- a/app/en-ca/resume-headline-generator/page.tsx
+++ b/app/en-ca/resume-headline-generator/page.tsx
@@ -1,0 +1,16 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/resume-headline-generator/page";
+
+export const metadata: Metadata = {
+  title: "Resume Headline Generator | Flashfire Canada",
+  description: "Generate 5 AI-powered, recruiter-tested resume headlines instantly. Free resume headline generator.",
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-ca/resume-headline-generator",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/resume-headline-generator",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/resume-headline-generator",
+      "x-default": "https://www.flashfirejobs.com/resume-headline-generator",
+    },
+  },
+};

--- a/app/en-ca/resume-parser/page.tsx
+++ b/app/en-ca/resume-parser/page.tsx
@@ -1,0 +1,16 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/resume-parser/page";
+
+export const metadata: Metadata = {
+  title: "Resume Parser | Flashfire Canada",
+  description: "Extract structured data from your resume instantly. Free online resume parser.",
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-ca/resume-parser",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/resume-parser",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/resume-parser",
+      "x-default": "https://www.flashfirejobs.com/resume-parser",
+    },
+  },
+};

--- a/app/en-ca/salary-calculator/page.tsx
+++ b/app/en-ca/salary-calculator/page.tsx
@@ -1,0 +1,24 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/salary-calculator/page";
+
+export const metadata: Metadata = {
+  title: "Salary Calculator – Estimate Take-Home Pay | Flashfire Canada",
+  description: "Calculate your take-home pay from annual salary. Includes bonus, pre-tax deductions, federal and provincial tax estimates.",
+  robots: { index: true, follow: true },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-ca/salary-calculator",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/salary-calculator",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/salary-calculator",
+      "x-default": "https://www.flashfirejobs.com/salary-calculator",
+    },
+  },
+  openGraph: {
+    title: "Salary Calculator – Estimate Take-Home Pay | Flashfire Canada",
+    description: "Calculate your take-home pay from annual salary. Includes bonus, pre-tax deductions, federal and provincial tax estimates.",
+    url: "https://www.flashfirejobs.com/en-ca/salary-calculator",
+    type: "website",
+  },
+  twitter: { card: "summary_large_image", images: ["https://www.flashfirejobs.com/images/og-image.png"] },
+};

--- a/app/en-ca/salary-comparison/page.tsx
+++ b/app/en-ca/salary-comparison/page.tsx
@@ -1,0 +1,24 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/salary-comparison/page";
+
+export const metadata: Metadata = {
+  title: "Salary Comparison – Compare Two Job Offers | Flashfire Canada",
+  description: "Compare two job offers side by side including salary, bonus, benefits, and commute costs to find the better total value.",
+  robots: { index: true, follow: true },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-ca/salary-comparison",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/salary-comparison",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/salary-comparison",
+      "x-default": "https://www.flashfirejobs.com/salary-comparison",
+    },
+  },
+  openGraph: {
+    title: "Salary Comparison – Compare Two Job Offers | Flashfire Canada",
+    description: "Compare two job offers side by side including salary, bonus, benefits, and commute costs to find the better total value.",
+    url: "https://www.flashfirejobs.com/en-ca/salary-comparison",
+    type: "website",
+  },
+  twitter: { card: "summary_large_image", images: ["https://www.flashfirejobs.com/images/og-image.png"] },
+};

--- a/app/en-ca/salary-estimator/page.tsx
+++ b/app/en-ca/salary-estimator/page.tsx
@@ -1,0 +1,24 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/salary-estimator/page";
+
+export const metadata: Metadata = {
+  title: "Salary Estimator – Realistic Salary Range by Role | Flashfire Canada",
+  description: "Estimate a salary range based on role, experience, location, and skill premium. Great for job offer planning and negotiation.",
+  robots: { index: true, follow: true },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-ca/salary-estimator",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/salary-estimator",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/salary-estimator",
+      "x-default": "https://www.flashfirejobs.com/salary-estimator",
+    },
+  },
+  openGraph: {
+    title: "Salary Estimator – Realistic Salary Range by Role | Flashfire Canada",
+    description: "Estimate a salary range based on role, experience, location, and skill premium. Great for job offer planning and negotiation.",
+    url: "https://www.flashfirejobs.com/en-ca/salary-estimator",
+    type: "website",
+  },
+  twitter: { card: "summary_large_image", images: ["https://www.flashfirejobs.com/images/og-image.png"] },
+};

--- a/app/en-ca/take-home-pay-calculator/page.tsx
+++ b/app/en-ca/take-home-pay-calculator/page.tsx
@@ -1,0 +1,24 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/take-home-pay-calculator/page";
+
+export const metadata: Metadata = {
+  title: "Take Home Pay Calculator – Net Paycheck Estimator | Flashfire Canada",
+  description: "See your actual take-home pay after taxes and deductions. Enter gross pay, frequency, and provincial tax to get your net paycheck.",
+  robots: { index: true, follow: true },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-ca/take-home-pay-calculator",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/take-home-pay-calculator",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/take-home-pay-calculator",
+      "x-default": "https://www.flashfirejobs.com/take-home-pay-calculator",
+    },
+  },
+  openGraph: {
+    title: "Take Home Pay Calculator – Net Paycheck Estimator | Flashfire Canada",
+    description: "See your actual take-home pay after taxes and deductions. Enter gross pay, frequency, and provincial tax to get your net paycheck.",
+    url: "https://www.flashfirejobs.com/en-ca/take-home-pay-calculator",
+    type: "website",
+  },
+  twitter: { card: "summary_large_image", images: ["https://www.flashfirejobs.com/images/og-image.png"] },
+};


### PR DESCRIPTION
## Summary
- Several navbar and footer links use locale-aware `getHref()`, but 27 pages had no corresponding `en-ca` route, causing 404s on Canada-locale URLs (e.g. `flashfirejobs.com/en-ca/features/automated-job-applications`).
- Added `en-ca` wrapper pages for all 27, following the existing pattern (e.g. `app/en-ca/features/resume-optimizer/page.tsx`): re-export the page content from the non-locale route, and set Canada-specific `title`/`description`/canonical/hreflang metadata.

**Navbar-linked feature pages (5):**
- `features/ai-cover-letter-generator`
- `features/ai-job-targeting`
- `features/automated-job-applications`
- `features/job-application-tracker`
- `features/linkedin-profile-optimization-tool`

**Footer-linked calculator/AI-tool pages (22):**
- `after-tax-income-calculator`, `ai-career-assessment-skill-gap-analysis`, `ai-follow-up-email-generator`, `ai-interview-answer-generator`, `ai-job-alerts`, `ai-job-matching-platform`, `ai-job-search-platform-for-freshers`, `ai-remote-job-search-platform`, `ai-resume-builder`, `ai-resume-summary-generator`, `ats-score-checker`, `cv-keyword-scanner`, `gross-pay-calculator`, `hourly-to-salary-calculator`, `interview-buddy`, `job-application-status-tracker`, `resume-bullet-point-generator`, `resume-headline-generator`, `resume-parser`, `salary-calculator`, `salary-comparison`, `salary-estimator`, `take-home-pay-calculator`

## Test plan
- [ ] `npm install && npm run build` completes without route errors
- [ ] Spot check a few URLs locally, e.g. `/en-ca/features/automated-job-applications`, `/en-ca/salary-calculator`, `/en-ca/ai-resume-builder` — should render (not 404) with Canada-specific metadata
- [ ] Confirm navbar/footer links on `en-ca` pages no longer 404