### PR TITLE
Add Anniversary Sale promo banner above navbar

### DIFF
--- a/src/components/navbar/navbar.tsx
+++ b/src/components/navbar/navbar.tsx
@@ -1,6 +1,12 @@
 import { navbarCTAs, navbarLinks } from "@/src/data/navbar";
 import NavbarClient from "./navbarClient";
+import PromoBanner from "../promoBanner/promoBanner";
 
 export default function Navbar() {
-  return <NavbarClient links={navbarLinks} ctas={navbarCTAs} />;
+  return (
+    <>
+      <PromoBanner />
+      <NavbarClient links={navbarLinks} ctas={navbarCTAs} />
+    </>
+  );
 }

--- a/src/components/promoBanner/promoBanner.module.css
+++ b/src/components/promoBanner/promoBanner.module.css
@@ -1,0 +1,113 @@
+.promoBar {
+  position: sticky;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 60;
+  background: #e85d1a;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  padding: 0 20px;
+  height: 44px;
+  user-select: none;
+  flex-wrap: wrap;
+}
+
+.promoLabel {
+  font-size: 13.5px;
+  font-weight: 800;
+  white-space: nowrap;
+}
+
+.promoDivider {
+  width: 1px;
+  height: 16px;
+  background: rgba(255, 255, 255, 0.35);
+  flex-shrink: 0;
+}
+
+.promoText {
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.92);
+  white-space: nowrap;
+}
+
+.promoEnds {
+  font-size: 13px;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.85);
+  white-space: nowrap;
+}
+
+.timer {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+}
+
+.tSeg {
+  background: rgba(0, 0, 0, 0.22);
+  border-radius: 5px;
+  width: 30px;
+  height: 26px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.tColon {
+  font-size: 13px;
+  font-weight: 800;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.btnPricing {
+  padding: 5px 14px;
+  border-radius: 6px;
+  border: 1.5px solid rgba(255, 255, 255, 0.8);
+  background: transparent;
+  color: #fff;
+  font-size: 12.5px;
+  font-weight: 700;
+  cursor: pointer;
+  text-decoration: none;
+  white-space: nowrap;
+  transition: background 0.2s ease;
+}
+
+.btnPricing:hover {
+  background: rgba(255, 255, 255, 0.15);
+}
+
+@media (max-width: 900px) {
+  .promoText {
+    display: none;
+  }
+
+  .promoDivider:nth-of-type(2) {
+    display: none;
+  }
+}
+
+@media (max-width: 640px) {
+  .promoBar {
+    height: auto;
+    padding: 8px 12px;
+    gap: 8px;
+  }
+
+  .btnPricing {
+    padding: 4px 10px;
+    font-size: 12px;
+  }
+
+  .tSeg {
+    width: 26px;
+    height: 22px;
+  }
+}

--- a/src/components/promoBanner/promoBanner.tsx
+++ b/src/components/promoBanner/promoBanner.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import styles from "./promoBanner.module.css";
+
+const SALE_END = (() => {
+  const end = new Date();
+  end.setHours(23, 59, 59, 999);
+  return end;
+})();
+
+function getTimeLeft() {
+  const diff = Math.max(0, SALE_END.getTime() - Date.now());
+
+  return {
+    hours: Math.floor(diff / (1000 * 60 * 60)),
+    minutes: Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60)),
+    seconds: Math.floor((diff % (1000 * 60)) / 1000),
+  };
+}
+
+function pad(n: number) {
+  return n.toString().padStart(2, "0");
+}
+
+type Props = {
+  pricingHref?: string;
+};
+
+export default function PromoBanner({ pricingHref = "/pricing" }: Props) {
+  const [timeLeft, setTimeLeft] = useState(getTimeLeft());
+
+  useEffect(() => {
+    const interval = setInterval(() => setTimeLeft(getTimeLeft()), 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <div className={styles.promoBar}>
+      <svg width="14" height="14" viewBox="0 0 20 20" fill="white">
+        <path d="M10 1l2.39 6.26H19l-5.31 3.86 2.02 6.26L10 13.52l-5.7 3.86 2.02-6.26L1 7.26h6.61L10 1z" />
+      </svg>
+      <span className={styles.promoLabel}>Anniversary Sale</span>
+      <div className={styles.promoDivider} />
+      <span className={styles.promoText}>
+        Celebrate with us — special anniversary pricing for a limited time.
+      </span>
+      <div className={styles.promoDivider} />
+      <span className={styles.promoEnds}>Ends in</span>
+      <div className={styles.timer}>
+        <div className={styles.tSeg}>{pad(timeLeft.hours)}</div>
+        <span className={styles.tColon}>:</span>
+        <div className={styles.tSeg}>{pad(timeLeft.minutes)}</div>
+        <span className={styles.tColon}>:</span>
+        <div className={styles.tSeg}>{pad(timeLeft.seconds)}</div>
+      </div>
+      <Link href={pricingHref} className={styles.btnPricing}>
+        View Pricing →
+      </Link>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a sticky "Anniversary Sale" promo bar rendered above the navbar on every page
- Includes a live countdown timer (resets daily at local midnight) and a "View Pricing" CTA linking to `/pricing`
- Wired in via `src/components/navbar/navbar.tsx` so no per-page changes are needed

## Test plan
- [x] Run `npm run dev` and confirm the banner renders above the navbar on the homepage and a few other routes
- [ ] Confirm the countdown timer updates every second
- [ ] Confirm "View Pricing" navigates to `/pricing`
- [ ] Check responsive behavior on mobile widths