### PR TITLE
Fix navbar hidden behind promo banner on scroll

### DIFF
--- a/src/components/navbar/navbar.tsx
+++ b/src/components/navbar/navbar.tsx
@@ -4,9 +4,9 @@ import PromoBanner from "../promoBanner/promoBanner";
 
 export default function Navbar() {
   return (
-    <>
+    <div className="sticky top-0 left-0 right-0 z-50">
       <PromoBanner />
       <NavbarClient links={navbarLinks} ctas={navbarCTAs} />
-    </>
+    </div>
   );
 }

--- a/src/components/navbar/navbarClient.tsx
+++ b/src/components/navbar/navbarClient.tsx
@@ -173,8 +173,7 @@ export default function NavbarClient({ links, ctas }: Props) {
 
   return (
     <>
-      {/* Sticky Container for Navbar */}
-      <div className="sticky top-0 left-0 right-0 z-50">
+      <div>
         <nav
           className={styles.navContainer}
           style={{

--- a/src/components/promoBanner/promoBanner.module.css
+++ b/src/components/promoBanner/promoBanner.module.css
@@ -1,9 +1,5 @@
 .promoBar {
-  position: sticky;
-  top: 0;
-  left: 0;
-  right: 0;
-  z-index: 60;
+  position: relative;
   background: #e85d1a;
   color: #fff;
   display: flex;


### PR DESCRIPTION
## Summary
- The Anniversary Sale promo banner and the main navbar were independent sibling elements, each with its own `position: sticky; top: 0`. Independent sticky siblings don't coordinate offsets, so on scroll the promo banner (z-index 60) rendered over the navbar (z-index 50), hiding the nav links (Home/Features/etc.) as shown in the reported screenshot.
- Wrapped `PromoBanner` and `NavbarClient` in a single shared `sticky top-0 z-50` container in `Navbar` so they now scroll and stick together as one unit, with the navbar always visible directly below the promo bar.

## Test plan
- [ ] `npm install && npm run dev`, load the homepage, scroll down, and confirm the navbar stays fully visible below the promo banner instead of being covered
- [ ] Confirm promo banner countdown/pricing link and navbar links/CTA still function normally
- [ ] Check mobile viewport — mobile menu and mobile bottom CTA bar still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)