### PR TITLE
Add /en-uk locale: UK & EU site with GBP pricing

### DIFF
--- a/app/AI-copilot/page.tsx
+++ b/app/AI-copilot/page.tsx
@@ -15,6 +15,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/AI-copilot",
       "en-CA": "https://www.flashfirejobs.com/en-ca/AI-copilot",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/AI-copilot",
       "x-default": "https://www.flashfirejobs.com/AI-copilot",
     },
   },

--- a/app/Job-Search-Immediately-near-me/JobSearchNearMeContent.tsx
+++ b/app/Job-Search-Immediately-near-me/JobSearchNearMeContent.tsx
@@ -5,6 +5,7 @@ import { trackButtonClick, trackSignupIntent } from "@/src/utils/PostHogTracking
 import { GTagUTM } from "@/src/utils/GTagUTM";
 import { useGeoBypass } from "@/src/utils/useGeoBypass";
 import { Target, Rocket, Handshake, Trophy } from "lucide-react";
+import { localizeHref, stripLocalePrefix } from "@/src/utils/locale";
 
 const steps = [
   {
@@ -89,12 +90,10 @@ export default function JobSearchNearMeContent() {
         (typeof window !== "undefined" ? window.location.pathname : "");
       const normalizedPath = currentPath.split("?")[0];
       const isAlreadyOnGetMeInterview =
-        normalizedPath === "/get-me-interview" ||
-        normalizedPath === "/en-ca/get-me-interview";
+        stripLocalePrefix(normalizedPath) === "/get-me-interview";
       const isOnJobSearchPage =
-        normalizedPath === "/job-search" ||
-        normalizedPath === "/en-ca/job-search" ||
-        normalizedPath === "/Job-Search-Immediately-near-me";
+        stripLocalePrefix(normalizedPath) === "/job-search" ||
+        stripLocalePrefix(normalizedPath) === "/Job-Search-Immediately-near-me";
 
       // If already on the route, save scroll position and prevent navigation
       if (isAlreadyOnGetMeInterview) {
@@ -137,9 +136,7 @@ export default function JobSearchNearMeContent() {
           );
         }
 
-        const targetPath = normalizedPath.startsWith("/en-ca")
-          ? "/en-ca/get-me-interview"
-          : "/get-me-interview";
+        const targetPath = localizeHref("/get-me-interview", normalizedPath);
         router.replace(targetPath);
         return;
       }

--- a/app/[locale]/blog/page.tsx
+++ b/app/[locale]/blog/page.tsx
@@ -13,9 +13,12 @@ interface LocaleBlogPageProps {
 export async function generateMetadata({ params }: LocaleBlogPageProps): Promise<Metadata> {
   const { locale } = await params;
   const isCanada = locale === "en-ca";
+  const isUK = locale === "en-uk";
   
   return {
-    title: isCanada 
+    title: isUK
+      ? "Blog - Career Tips, Job Search Advice & Industry Insights | Flashfire (UK)"
+      : isCanada
       ? "Blog - Career Tips, Job Search Advice & Industry Insights | Flashfire (Canada)"
       : "Blog - Career Tips, Job Search Advice & Industry Insights | Flashfire",
     description:
@@ -25,17 +28,21 @@ export async function generateMetadata({ params }: LocaleBlogPageProps): Promise
       follow: false,
     },
     alternates: {
-      canonical: isCanada 
-        ? "https://www.flashfirejobs.com/en-ca/blog"
-        : "https://www.flashfirejobs.com/blog",
+      canonical: isUK
+      ? "https://www.flashfirejobs.com/en-uk/blog"
+      : isCanada
+      ? "https://www.flashfirejobs.com/en-ca/blog"
+      : "https://www.flashfirejobs.com/blog",
     },
     openGraph: {
       title: "Blog - Career Tips & Job Search Advice",
       description:
         "Discover expert career tips, job search strategies, and industry insights.",
-      url: isCanada 
-        ? "https://www.flashfirejobs.com/en-ca/blog"
-        : "https://www.flashfirejobs.com/blog",
+      url: isUK
+      ? "https://www.flashfirejobs.com/en-uk/blog"
+      : isCanada
+      ? "https://www.flashfirejobs.com/en-ca/blog"
+      : "https://www.flashfirejobs.com/blog",
       type: "website",
       images: [
         {

--- a/app/[locale]/blogs/page.tsx
+++ b/app/[locale]/blogs/page.tsx
@@ -13,9 +13,12 @@ interface LocaleBlogsPageProps {
 export async function generateMetadata({ params }: LocaleBlogsPageProps): Promise<Metadata> {
   const { locale } = await params;
   const isCanada = locale === "en-ca";
+  const isUK = locale === "en-uk";
   
   return {
-    title: isCanada 
+    title: isUK
+      ? "Blog - Career Tips, Job Search Advice & Industry Insights | Flashfire (UK)"
+      : isCanada
       ? "Blog - Career Tips, Job Search Advice & Industry Insights | Flashfire (Canada)"
       : "Blog - Career Tips, Job Search Advice & Industry Insights | Flashfire",
     description:
@@ -25,17 +28,21 @@ export async function generateMetadata({ params }: LocaleBlogsPageProps): Promis
       follow: false,
     },
     alternates: {
-      canonical: isCanada 
-        ? "https://www.flashfirejobs.com/en-ca/blog"
-        : "https://www.flashfirejobs.com/blog",
+      canonical: isUK
+      ? "https://www.flashfirejobs.com/en-uk/blog"
+      : isCanada
+      ? "https://www.flashfirejobs.com/en-ca/blog"
+      : "https://www.flashfirejobs.com/blog",
     },
     openGraph: {
       title: "Blog - Career Tips & Job Search Advice",
       description:
         "Discover expert career tips, job search strategies, and industry insights.",
-      url: isCanada 
-        ? "https://www.flashfirejobs.com/en-ca/blog"
-        : "https://www.flashfirejobs.com/blog",
+      url: isUK
+      ? "https://www.flashfirejobs.com/en-uk/blog"
+      : isCanada
+      ? "https://www.flashfirejobs.com/en-ca/blog"
+      : "https://www.flashfirejobs.com/blog",
       type: "website",
       images: [
         {

--- a/app/[locale]/employers/page.tsx
+++ b/app/[locale]/employers/page.tsx
@@ -12,9 +12,12 @@ interface LocaleEmployersPageProps {
 export async function generateMetadata({ params }: LocaleEmployersPageProps): Promise<Metadata> {
   const { locale } = await params;
   const isCanada = locale === "en-ca";
+  const isUK = locale === "en-uk";
   
   return {
-    title: isCanada 
+    title: isUK
+      ? "Employers - Partner with Flashfire | Hire Top Talent Faster (UK)"
+      : isCanada
       ? "Employers - Partner with Flashfire | Hire Top Talent Faster (Canada)"
       : "Employers - Partner with Flashfire | Hire Top Talent Faster",
     description:
@@ -24,17 +27,21 @@ export async function generateMetadata({ params }: LocaleEmployersPageProps): Pr
       follow: false,
     },
     alternates: {
-      canonical: isCanada 
-        ? "https://www.flashfirejobs.com/en-ca/employers"
-        : "https://www.flashfirejobs.com/employers",
+      canonical: isUK
+      ? "https://www.flashfirejobs.com/en-uk/employers"
+      : isCanada
+      ? "https://www.flashfirejobs.com/en-ca/employers"
+      : "https://www.flashfirejobs.com/employers",
     },
     openGraph: {
       title: "Employers - Partner with Flashfire",
       description:
         "Partner with Flashfire to access pre-screened, qualified candidates.",
-      url: isCanada 
-        ? "https://www.flashfirejobs.com/en-ca/employers"
-        : "https://www.flashfirejobs.com/employers",
+      url: isUK
+      ? "https://www.flashfirejobs.com/en-uk/employers"
+      : isCanada
+      ? "https://www.flashfirejobs.com/en-ca/employers"
+      : "https://www.flashfirejobs.com/employers",
       type: "website",
     },
   };

--- a/app/[locale]/faq/page.tsx
+++ b/app/[locale]/faq/page.tsx
@@ -10,9 +10,12 @@ interface LocaleFAQPageProps {
 export async function generateMetadata({ params }: LocaleFAQPageProps): Promise<Metadata> {
   const { locale } = await params;
   const isCanada = locale === "en-ca";
+  const isUK = locale === "en-uk";
   
   return {
-    title: isCanada 
+    title: isUK
+      ? "FAQ - Frequently Asked Questions | Flashfire (UK)"
+      : isCanada
       ? "FAQ - Frequently Asked Questions | Flashfire (Canada)"
       : "FAQ - Frequently Asked Questions | Flashfire",
     description:
@@ -22,17 +25,21 @@ export async function generateMetadata({ params }: LocaleFAQPageProps): Promise<
       follow: false,
     },
     alternates: {
-      canonical: isCanada 
-        ? "https://www.flashfirejobs.com/en-ca/faq"
-        : "https://www.flashfirejobs.com/faq",
+      canonical: isUK
+      ? "https://www.flashfirejobs.com/en-uk/faq"
+      : isCanada
+      ? "https://www.flashfirejobs.com/en-ca/faq"
+      : "https://www.flashfirejobs.com/faq",
     },
     openGraph: {
       title: "FAQ - Frequently Asked Questions",
       description:
         "Find answers to common questions about Flashfire's job search automation service.",
-      url: isCanada 
-        ? "https://www.flashfirejobs.com/en-ca/faq"
-        : "https://www.flashfirejobs.com/faq",
+      url: isUK
+      ? "https://www.flashfirejobs.com/en-uk/faq"
+      : isCanada
+      ? "https://www.flashfirejobs.com/en-ca/faq"
+      : "https://www.flashfirejobs.com/faq",
       type: "website",
     },
   };

--- a/app/[locale]/feature/page.tsx
+++ b/app/[locale]/feature/page.tsx
@@ -10,9 +10,12 @@ interface LocaleFeaturePageProps {
 export async function generateMetadata({ params }: LocaleFeaturePageProps): Promise<Metadata> {
   const { locale } = await params;
   const isCanada = locale === "en-ca";
+  const isUK = locale === "en-uk";
   
   return {
-    title: isCanada 
+    title: isUK
+      ? "Features - Job Search Automation Tools | Flashfire (UK)"
+      : isCanada
       ? "Features - Job Search Automation Tools | Flashfire (Canada)"
       : "Features - Job Search Automation Tools | Flashfire",
     description:
@@ -22,17 +25,21 @@ export async function generateMetadata({ params }: LocaleFeaturePageProps): Prom
       follow: false,
     },
     alternates: {
-      canonical: isCanada 
-        ? "https://www.flashfirejobs.com/en-ca/feature"
-        : "https://www.flashfirejobs.com/feature",
+      canonical: isUK
+      ? "https://www.flashfirejobs.com/en-uk/feature"
+      : isCanada
+      ? "https://www.flashfirejobs.com/en-ca/feature"
+      : "https://www.flashfirejobs.com/feature",
     },
     openGraph: {
       title: "Features - Job Search Automation Tools",
       description:
         "Discover Flashfire's powerful features for automated job search and resume optimization.",
-      url: isCanada 
-        ? "https://www.flashfirejobs.com/en-ca/feature"
-        : "https://www.flashfirejobs.com/feature",
+      url: isUK
+      ? "https://www.flashfirejobs.com/en-uk/feature"
+      : isCanada
+      ? "https://www.flashfirejobs.com/en-ca/feature"
+      : "https://www.flashfirejobs.com/feature",
       type: "website",
     },
   };

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -4,10 +4,11 @@ import { notFound } from "next/navigation";
 export const dynamicParams = false;
 
 export async function generateStaticParams() {
-  return [{ locale: "en-ca" }];
+  return [{ locale: "en-ca" }, { locale: "en-uk" }];
 }
 import HomePage from "@/src/components/pages/home/Home";
 import CanadaHome from "@/src/components/countries/ca/Home";
+import UKHome from "@/src/components/countries/uk/Home";
 
 interface LocalePageProps {
   params: Promise<{
@@ -15,11 +16,44 @@ interface LocalePageProps {
   }>;
 }
 
-const validLocales = ["en-ca"];
-
 export async function generateMetadata({ params }: LocalePageProps): Promise<Metadata> {
   const { locale } = await params;
   const isCanada = locale === "en-ca";
+  const isUK = locale === "en-uk";
+
+  if (isUK) {
+    return {
+      title: "FLASHFIRE - AI-Powered Job Search Automation | Land Your Dream Job Faster (UK)",
+      description:
+        "We apply to 1000+ jobs on your behalf with tailored CVs for every role. Save 150+ hours, skip the grunt work, and stay in control with real-time updates. Your job hunt—automated.",
+      robots: {
+        index: true,
+        follow: true,
+      },
+      alternates: {
+        canonical: "https://www.flashfirejobs.com/en-uk",
+      },
+      openGraph: {
+        title: "FLASHFIRE - AI-Powered Job Search Automation (UK)",
+        description:
+          "We apply to 1000+ jobs on your behalf with tailored CVs for every role. Save 150+ hours, skip the grunt work, and stay in control with real-time updates.",
+        url: "https://www.flashfirejobs.com/en-uk",
+        type: "website",
+        images: [
+          {
+            url: "https://www.flashfirejobs.com/images/og-image.png",
+            width: 1200,
+            height: 630,
+            alt: "FLASHFIRE Logo",
+          },
+        ],
+      },
+      twitter: {
+        card: "summary_large_image",
+        images: ["https://www.flashfirejobs.com/images/og-image.png"],
+      },
+    };
+  }
 
   if (!isCanada) {
     return {
@@ -102,6 +136,11 @@ export default async function LocalePage({ params }: LocalePageProps) {
   // Handle Canada locale
   if (locale === "en-ca") {
     return <CanadaHome />;
+  }
+
+  // Handle UK / EU locale
+  if (locale === "en-uk") {
+    return <UKHome />;
   }
 
   // Invalid locale - 404

--- a/app/[locale]/payment-policy/page.tsx
+++ b/app/[locale]/payment-policy/page.tsx
@@ -12,9 +12,12 @@ interface LocalePaymentPolicyPageProps {
 export async function generateMetadata({ params }: LocalePaymentPolicyPageProps): Promise<Metadata> {
   const { locale } = await params;
   const isCanada = locale === "en-ca";
+  const isUK = locale === "en-uk";
   
   return {
-    title: isCanada 
+    title: isUK
+      ? "Payment Policy | Flashfire (UK)"
+      : isCanada
       ? "Payment Policy | Flashfire (Canada)"
       : "Payment Policy | Flashfire",
     description:
@@ -24,17 +27,21 @@ export async function generateMetadata({ params }: LocalePaymentPolicyPageProps)
       follow: false,
     },
     alternates: {
-      canonical: isCanada 
-        ? "https://www.flashfirejobs.com/en-ca/payment-policy"
-        : "https://www.flashfirejobs.com/payment-policy",
+      canonical: isUK
+      ? "https://www.flashfirejobs.com/en-uk/payment-policy"
+      : isCanada
+      ? "https://www.flashfirejobs.com/en-ca/payment-policy"
+      : "https://www.flashfirejobs.com/payment-policy",
     },
     openGraph: {
       title: "Payment Policy | Flashfire",
       description:
         "Read Flashfire's Payment Policy to understand our payment terms.",
-      url: isCanada 
-        ? "https://www.flashfirejobs.com/en-ca/payment-policy"
-        : "https://www.flashfirejobs.com/payment-policy",
+      url: isUK
+      ? "https://www.flashfirejobs.com/en-uk/payment-policy"
+      : isCanada
+      ? "https://www.flashfirejobs.com/en-ca/payment-policy"
+      : "https://www.flashfirejobs.com/payment-policy",
       type: "website",
     },
   };

--- a/app/[locale]/pricing/page.tsx
+++ b/app/[locale]/pricing/page.tsx
@@ -15,9 +15,12 @@ interface LocalePricingPageProps {
 export async function generateMetadata({ params }: LocalePricingPageProps): Promise<Metadata> {
   const { locale } = await params;
   const isCanada = locale === "en-ca";
+  const isUK = locale === "en-uk";
   
   return {
-    title: isCanada 
+    title: isUK
+      ? "Pricing - Affordable Job Search Automation Plans | Flashfire UK"
+      : isCanada
       ? "Pricing - Affordable Job Search Automation Plans | Flashfire CA"
       : "Pricing - Affordable Job Search Automation Plans | Flashfire",
     description:
@@ -27,17 +30,21 @@ export async function generateMetadata({ params }: LocalePricingPageProps): Prom
       follow: false,
     },
     alternates: {
-      canonical: isCanada 
-        ? "https://www.flashfirejobs.com/en-ca/pricing"
-        : "https://www.flashfirejobs.com/pricing",
+      canonical: isUK
+      ? "https://www.flashfirejobs.com/en-uk/pricing"
+      : isCanada
+      ? "https://www.flashfirejobs.com/en-ca/pricing"
+      : "https://www.flashfirejobs.com/pricing",
     },
     openGraph: {
       title: "Pricing - Affordable Job Search Automation Plans",
       description:
         "Choose the perfect Flashfire plan for your job search automation.",
-      url: isCanada 
-        ? "https://www.flashfirejobs.com/en-ca/pricing"
-        : "https://www.flashfirejobs.com/pricing",
+      url: isUK
+      ? "https://www.flashfirejobs.com/en-uk/pricing"
+      : isCanada
+      ? "https://www.flashfirejobs.com/en-ca/pricing"
+      : "https://www.flashfirejobs.com/pricing",
       type: "website",
     },
   };

--- a/app/[locale]/privacy-policy/page.tsx
+++ b/app/[locale]/privacy-policy/page.tsx
@@ -12,9 +12,12 @@ interface LocalePrivacyPolicyPageProps {
 export async function generateMetadata({ params }: LocalePrivacyPolicyPageProps): Promise<Metadata> {
   const { locale } = await params;
   const isCanada = locale === "en-ca";
+  const isUK = locale === "en-uk";
   
   return {
-    title: isCanada 
+    title: isUK
+      ? "Privacy Policy | Flashfire (UK)"
+      : isCanada
       ? "Privacy Policy | Flashfire (Canada)"
       : "Privacy Policy | Flashfire",
     description:
@@ -24,17 +27,21 @@ export async function generateMetadata({ params }: LocalePrivacyPolicyPageProps)
       follow: false,
     },
     alternates: {
-      canonical: isCanada 
-        ? "https://www.flashfirejobs.com/en-ca/privacy-policy"
-        : "https://www.flashfirejobs.com/privacy-policy",
+      canonical: isUK
+      ? "https://www.flashfirejobs.com/en-uk/privacy-policy"
+      : isCanada
+      ? "https://www.flashfirejobs.com/en-ca/privacy-policy"
+      : "https://www.flashfirejobs.com/privacy-policy",
     },
     openGraph: {
       title: "Privacy Policy | Flashfire",
       description:
         "Read Flashfire's Privacy Policy to understand how we protect your personal information.",
-      url: isCanada 
-        ? "https://www.flashfirejobs.com/en-ca/privacy-policy"
-        : "https://www.flashfirejobs.com/privacy-policy",
+      url: isUK
+      ? "https://www.flashfirejobs.com/en-uk/privacy-policy"
+      : isCanada
+      ? "https://www.flashfirejobs.com/en-ca/privacy-policy"
+      : "https://www.flashfirejobs.com/privacy-policy",
       type: "website",
     },
   };

--- a/app/[locale]/refund-policy/page.tsx
+++ b/app/[locale]/refund-policy/page.tsx
@@ -12,9 +12,12 @@ interface LocaleRefundPolicyPageProps {
 export async function generateMetadata({ params }: LocaleRefundPolicyPageProps): Promise<Metadata> {
   const { locale } = await params;
   const isCanada = locale === "en-ca";
+  const isUK = locale === "en-uk";
   
   return {
-    title: isCanada 
+    title: isUK
+      ? "Refund Policy | Flashfire (UK)"
+      : isCanada
       ? "Refund Policy | Flashfire (Canada)"
       : "Refund Policy | Flashfire",
     description:
@@ -24,17 +27,21 @@ export async function generateMetadata({ params }: LocaleRefundPolicyPageProps):
       follow: false,
     },
     alternates: {
-      canonical: isCanada 
-        ? "https://www.flashfirejobs.com/en-ca/refund-policy"
-        : "https://www.flashfirejobs.com/refund-policy",
+      canonical: isUK
+      ? "https://www.flashfirejobs.com/en-uk/refund-policy"
+      : isCanada
+      ? "https://www.flashfirejobs.com/en-ca/refund-policy"
+      : "https://www.flashfirejobs.com/refund-policy",
     },
     openGraph: {
       title: "Refund Policy | Flashfire",
       description:
         "Read Flashfire's Refund Policy to understand our refund terms.",
-      url: isCanada 
-        ? "https://www.flashfirejobs.com/en-ca/refund-policy"
-        : "https://www.flashfirejobs.com/refund-policy",
+      url: isUK
+      ? "https://www.flashfirejobs.com/en-uk/refund-policy"
+      : isCanada
+      ? "https://www.flashfirejobs.com/en-ca/refund-policy"
+      : "https://www.flashfirejobs.com/refund-policy",
       type: "website",
     },
   };

--- a/app/[locale]/terms-of-service/page.tsx
+++ b/app/[locale]/terms-of-service/page.tsx
@@ -12,9 +12,12 @@ interface LocaleTermsOfServicePageProps {
 export async function generateMetadata({ params }: LocaleTermsOfServicePageProps): Promise<Metadata> {
   const { locale } = await params;
   const isCanada = locale === "en-ca";
+  const isUK = locale === "en-uk";
   
   return {
-    title: isCanada 
+    title: isUK
+      ? "Terms of Service | Flashfire (UK)"
+      : isCanada
       ? "Terms of Service | Flashfire (Canada)"
       : "Terms of Service | Flashfire",
     description:
@@ -24,17 +27,21 @@ export async function generateMetadata({ params }: LocaleTermsOfServicePageProps
       follow: false,
     },
     alternates: {
-      canonical: isCanada 
-        ? "https://www.flashfirejobs.com/en-ca/terms-of-service"
-        : "https://www.flashfirejobs.com/terms-of-service",
+      canonical: isUK
+      ? "https://www.flashfirejobs.com/en-uk/terms-of-service"
+      : isCanada
+      ? "https://www.flashfirejobs.com/en-ca/terms-of-service"
+      : "https://www.flashfirejobs.com/terms-of-service",
     },
     openGraph: {
       title: "Terms of Service | Flashfire",
       description:
         "Read Flashfire's Terms of Service to understand our terms and conditions.",
-      url: isCanada 
-        ? "https://www.flashfirejobs.com/en-ca/terms-of-service"
-        : "https://www.flashfirejobs.com/terms-of-service",
+      url: isUK
+      ? "https://www.flashfirejobs.com/en-uk/terms-of-service"
+      : isCanada
+      ? "https://www.flashfirejobs.com/en-ca/terms-of-service"
+      : "https://www.flashfirejobs.com/terms-of-service",
       type: "website",
     },
   };

--- a/app/[locale]/testimonials/page.tsx
+++ b/app/[locale]/testimonials/page.tsx
@@ -10,9 +10,12 @@ interface LocaleTestimonialsPageProps {
 export async function generateMetadata({ params }: LocaleTestimonialsPageProps): Promise<Metadata> {
   const { locale } = await params;
   const isCanada = locale === "en-ca";
+  const isUK = locale === "en-uk";
   
   return {
-    title: isCanada 
+    title: isUK
+      ? "Testimonials - Success Stories from Flashfire Users | Flashfire (UK)"
+      : isCanada
       ? "Testimonials - Success Stories from Flashfire Users | Flashfire (Canada)"
       : "Testimonials - Success Stories from Flashfire Users | Flashfire",
     description:
@@ -22,17 +25,21 @@ export async function generateMetadata({ params }: LocaleTestimonialsPageProps):
       follow: false,
     },
     alternates: {
-      canonical: isCanada 
-        ? "https://www.flashfirejobs.com/en-ca/testimonials"
-        : "https://www.flashfirejobs.com/testimonials",
+      canonical: isUK
+      ? "https://www.flashfirejobs.com/en-uk/testimonials"
+      : isCanada
+      ? "https://www.flashfirejobs.com/en-ca/testimonials"
+      : "https://www.flashfirejobs.com/testimonials",
     },
     openGraph: {
       title: "Testimonials - Success Stories from Flashfire Users",
       description:
         "Read success stories from job seekers who used Flashfire to land their dream jobs.",
-      url: isCanada 
-        ? "https://www.flashfirejobs.com/en-ca/testimonials"
-        : "https://www.flashfirejobs.com/testimonials",
+      url: isUK
+      ? "https://www.flashfirejobs.com/en-uk/testimonials"
+      : isCanada
+      ? "https://www.flashfirejobs.com/en-ca/testimonials"
+      : "https://www.flashfirejobs.com/testimonials",
       type: "website",
     },
   };

--- a/app/ats-optimized-resume-checker/page.tsx
+++ b/app/ats-optimized-resume-checker/page.tsx
@@ -24,6 +24,7 @@ import {
 import { trackButtonClick, trackSignupIntent } from "@/src/utils/PostHogTracking"
 import { GTagUTM } from "@/src/utils/GTagUTM"
 import { useGeoBypass } from "@/src/utils/useGeoBypass"
+import { localizeHref, stripLocalePrefix } from "@/src/utils/locale";
 
 // Minimal UI primitives (local) to avoid missing imports
 type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
@@ -140,10 +141,8 @@ export default function Page() {
       // Check current path first
       const currentPath = pathname || (typeof window !== 'undefined' ? window.location.pathname : '')
       const normalizedPath = currentPath.split('?')[0] // Remove query params
-      const isAlreadyOnGetMeInterview = normalizedPath === '/get-me-interview' ||
-        normalizedPath === '/en-ca/get-me-interview'
-      const isOnATSPage = normalizedPath === '/ats-optimized-resume-checker' ||
-        normalizedPath === '/en-ca/ats-optimized-resume-checker'
+      const isAlreadyOnGetMeInterview = stripLocalePrefix(normalizedPath) === '/get-me-interview'
+      const isOnATSPage = stripLocalePrefix(normalizedPath) === '/ats-optimized-resume-checker'
 
       // If already on the route, save scroll position and prevent navigation
       if (isAlreadyOnGetMeInterview) {
@@ -179,7 +178,7 @@ export default function Page() {
           sessionStorage.setItem('preserveScrollPosition', currentScrollY.toString())
         }
 
-        const targetPath = normalizedPath.startsWith('/en-ca') ? '/en-ca/get-me-interview' : '/get-me-interview'
+        const targetPath = localizeHref('/get-me-interview', normalizedPath)
         router.replace(targetPath)
         return
       }
@@ -212,8 +211,7 @@ export default function Page() {
     // Check current path
     const currentPath = pathname || (typeof window !== 'undefined' ? window.location.pathname : '')
     const normalizedPath = currentPath.split('?')[0]
-    const isOnATSPage = normalizedPath === '/ats-optimized-resume-checker' ||
-      normalizedPath === '/en-ca/ats-optimized-resume-checker'
+    const isOnATSPage = stripLocalePrefix(normalizedPath) === '/ats-optimized-resume-checker'
 
     // If on ATS page, scroll to the "How It Works" section
     if (isOnATSPage && typeof window !== 'undefined') {
@@ -225,7 +223,7 @@ export default function Page() {
     }
 
     // Otherwise, navigate to the How It Works page
-    const targetPath = normalizedPath.startsWith('/en-ca') ? '/en-ca/how-it-works' : '/how-it-works'
+    const targetPath = localizeHref('/how-it-works', normalizedPath)
     router.push(targetPath)
   }
 

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -21,6 +21,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/blog",
       "en-CA": "https://www.flashfirejobs.com/en-ca/blog",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/blog",
       "x-default": "https://www.flashfirejobs.com/blog",
     },
   },

--- a/app/book-a-demo/page.tsx
+++ b/app/book-a-demo/page.tsx
@@ -5,6 +5,7 @@ import HomePage from "@/src/components/pages/home/Home";
 import AboutUs from "@/src/components/pages/aboutUs/AboutUs";
 import Navbar from "@/src/components/navbar/navbar";
 import Footer from "@/src/components/footer/footer";
+import { stripLocalePrefix } from "@/src/utils/locale";
 
 
 export default function BookADemoPage() {
@@ -46,7 +47,7 @@ export default function BookADemoPage() {
         return <HomePage />;
     }
 
-    if (previousPage === '/about-us' || previousPage === '/en-ca/about-us') {
+    if (stripLocalePrefix(previousPage) === '/about-us') {
         return (
             <>
                 <Navbar />

--- a/app/book-my-demo-call/page.tsx
+++ b/app/book-my-demo-call/page.tsx
@@ -6,6 +6,7 @@ import HomePage from "@/src/components/pages/home/Home";
 import AboutUs from "@/src/components/pages/aboutUs/AboutUs";
 import Navbar from "@/src/components/navbar/navbar";
 import Footer from "@/src/components/footer/footer";
+import { stripLocalePrefix } from "@/src/utils/locale";
 
 
 export default function BookMyDemoCallPage() {
@@ -47,7 +48,7 @@ export default function BookMyDemoCallPage() {
         return <HomePage />;
     }
 
-    if (previousPage === '/about-us' || previousPage === '/en-ca/about-us') {
+    if (stripLocalePrefix(previousPage) === '/about-us') {
         return (
             <>
                 <Navbar />

--- a/app/book-now/page.tsx
+++ b/app/book-now/page.tsx
@@ -7,6 +7,7 @@ import HowItWorks from "@/src/components/pages/howItWorks/HowItWorks";
 import PricingPageClient from "../pricing/PricingPageClient";
 import Navbar from "@/src/components/navbar/navbar";
 import Footer from "@/src/components/footer/footer";
+import { stripLocalePrefix } from "@/src/utils/locale";
 
 export default function BookNowPage() {
     // Start with null to match server render, then update on client
@@ -59,7 +60,7 @@ export default function BookNowPage() {
     }
 
     // Render based on previous page (client-side only after mount)
-    if (previousPage === '/features' || previousPage === '/en-ca/features') {
+    if (stripLocalePrefix(previousPage) === '/features') {
         return (
             <div className="bg-white text-black min-h-screen">
                 <Navbar />
@@ -71,15 +72,15 @@ export default function BookNowPage() {
         );
     }
     
-    if (previousPage === '/how-it-works' || previousPage === '/en-ca/how-it-works') {
+    if (stripLocalePrefix(previousPage) === '/how-it-works') {
         return <HowItWorks />;
     }
     
-    if (previousPage === '/pricing' || previousPage === '/en-ca/pricing') {
+    if (stripLocalePrefix(previousPage) === '/pricing') {
         return <PricingPageClient />;
     }
     
-    if (previousPage === '/feature' || previousPage === '/en-ca/feature') {
+    if (stripLocalePrefix(previousPage) === '/feature') {
         return <HomePage />;
     }
 

--- a/app/career-advisor/page.tsx
+++ b/app/career-advisor/page.tsx
@@ -15,6 +15,7 @@ export const metadata: Metadata = {
         languages: {
             "en-US": "https://www.flashfirejobs.com/career-advisor",
             "en-CA": "https://www.flashfirejobs.com/en-ca/career-advisor",
+            "en-GB": "https://www.flashfirejobs.com/en-uk/career-advisor",
             "x-default": "https://www.flashfirejobs.com/career-advisor",
         },
     },

--- a/app/contact-us/page.tsx
+++ b/app/contact-us/page.tsx
@@ -16,6 +16,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/contact-us",
       "en-CA": "https://www.flashfirejobs.com/en-ca/contact-us",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/contact-us",
       "x-default": "https://www.flashfirejobs.com/contact-us",
     },
   },

--- a/app/employers/page.tsx
+++ b/app/employers/page.tsx
@@ -16,6 +16,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/employers",
       "en-CA": "https://www.flashfirejobs.com/en-ca/employers",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/employers",
       "x-default": "https://www.flashfirejobs.com/employers",
     },
   },

--- a/app/en-ca/AI-copilot/page.tsx
+++ b/app/en-ca/AI-copilot/page.tsx
@@ -15,6 +15,7 @@ const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/AI-copilot",
       "en-CA": "https://www.flashfirejobs.com/en-ca/AI-copilot",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/AI-copilot",
       "x-default": "https://www.flashfirejobs.com/AI-copilot",
     },
   },

--- a/app/en-ca/about-us/page.tsx
+++ b/app/en-ca/about-us/page.tsx
@@ -16,6 +16,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/about-us",
       "en-CA": "https://www.flashfirejobs.com/en-ca/about-us",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/about-us",
       "x-default": "https://www.flashfirejobs.com/about-us",
     },
   },

--- a/app/en-ca/after-tax-income-calculator/page.tsx
+++ b/app/en-ca/after-tax-income-calculator/page.tsx
@@ -11,6 +11,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/after-tax-income-calculator",
       "en-CA": "https://www.flashfirejobs.com/en-ca/after-tax-income-calculator",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/after-tax-income-calculator",
       "x-default": "https://www.flashfirejobs.com/after-tax-income-calculator",
     },
   },

--- a/app/en-ca/ai-career-assessment-skill-gap-analysis/page.tsx
+++ b/app/en-ca/ai-career-assessment-skill-gap-analysis/page.tsx
@@ -12,6 +12,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/ai-career-assessment-skill-gap-analysis",
       "en-CA": "https://www.flashfirejobs.com/en-ca/ai-career-assessment-skill-gap-analysis",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/ai-career-assessment-skill-gap-analysis",
       "x-default": "https://www.flashfirejobs.com/ai-career-assessment-skill-gap-analysis",
     },
   },

--- a/app/en-ca/ai-follow-up-email-generator/page.tsx
+++ b/app/en-ca/ai-follow-up-email-generator/page.tsx
@@ -12,6 +12,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/ai-follow-up-email-generator",
       "en-CA": "https://www.flashfirejobs.com/en-ca/ai-follow-up-email-generator",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/ai-follow-up-email-generator",
       "x-default": "https://www.flashfirejobs.com/ai-follow-up-email-generator",
     },
   },

--- a/app/en-ca/ai-interview-answer-generator/page.tsx
+++ b/app/en-ca/ai-interview-answer-generator/page.tsx
@@ -11,6 +11,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/ai-interview-answer-generator",
       "en-CA": "https://www.flashfirejobs.com/en-ca/ai-interview-answer-generator",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/ai-interview-answer-generator",
       "x-default": "https://www.flashfirejobs.com/ai-interview-answer-generator",
     },
   },

--- a/app/en-ca/ai-job-alerts/page.tsx
+++ b/app/en-ca/ai-job-alerts/page.tsx
@@ -12,6 +12,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/ai-job-alerts",
       "en-CA": "https://www.flashfirejobs.com/en-ca/ai-job-alerts",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/ai-job-alerts",
       "x-default": "https://www.flashfirejobs.com/ai-job-alerts",
     },
   },

--- a/app/en-ca/ai-job-matching-platform/page.tsx
+++ b/app/en-ca/ai-job-matching-platform/page.tsx
@@ -12,6 +12,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/ai-job-matching-platform",
       "en-CA": "https://www.flashfirejobs.com/en-ca/ai-job-matching-platform",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/ai-job-matching-platform",
       "x-default": "https://www.flashfirejobs.com/ai-job-matching-platform",
     },
   },

--- a/app/en-ca/ai-job-search-platform-for-freshers/page.tsx
+++ b/app/en-ca/ai-job-search-platform-for-freshers/page.tsx
@@ -12,6 +12,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/ai-job-search-platform-for-freshers",
       "en-CA": "https://www.flashfirejobs.com/en-ca/ai-job-search-platform-for-freshers",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/ai-job-search-platform-for-freshers",
       "x-default": "https://www.flashfirejobs.com/ai-job-search-platform-for-freshers",
     },
   },

--- a/app/en-ca/ai-remote-job-search-platform/page.tsx
+++ b/app/en-ca/ai-remote-job-search-platform/page.tsx
@@ -12,6 +12,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/ai-remote-job-search-platform",
       "en-CA": "https://www.flashfirejobs.com/en-ca/ai-remote-job-search-platform",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/ai-remote-job-search-platform",
       "x-default": "https://www.flashfirejobs.com/ai-remote-job-search-platform",
     },
   },

--- a/app/en-ca/ai-resume-builder/page.tsx
+++ b/app/en-ca/ai-resume-builder/page.tsx
@@ -12,6 +12,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/ai-resume-builder",
       "en-CA": "https://www.flashfirejobs.com/en-ca/ai-resume-builder",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/ai-resume-builder",
       "x-default": "https://www.flashfirejobs.com/ai-resume-builder",
     },
   },

--- a/app/en-ca/ai-resume-summary-generator/page.tsx
+++ b/app/en-ca/ai-resume-summary-generator/page.tsx
@@ -11,6 +11,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/ai-resume-summary-generator",
       "en-CA": "https://www.flashfirejobs.com/en-ca/ai-resume-summary-generator",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/ai-resume-summary-generator",
       "x-default": "https://www.flashfirejobs.com/ai-resume-summary-generator",
     },
   },

--- a/app/en-ca/ats-score-checker/page.tsx
+++ b/app/en-ca/ats-score-checker/page.tsx
@@ -10,6 +10,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/ats-score-checker",
       "en-CA": "https://www.flashfirejobs.com/en-ca/ats-score-checker",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/ats-score-checker",
       "x-default": "https://www.flashfirejobs.com/ats-score-checker",
     },
   },

--- a/app/en-ca/blog/page.tsx
+++ b/app/en-ca/blog/page.tsx
@@ -17,6 +17,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/blog",
       "en-CA": "https://www.flashfirejobs.com/en-ca/blog",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/blog",
       "x-default": "https://www.flashfirejobs.com/blog",
     },
   },

--- a/app/en-ca/career-advisor/page.tsx
+++ b/app/en-ca/career-advisor/page.tsx
@@ -15,6 +15,7 @@ export const metadata: Metadata = {
         languages: {
             "en-US": "https://www.flashfirejobs.com/career-advisor",
             "en-CA": "https://www.flashfirejobs.com/en-ca/career-advisor",
+            "en-GB": "https://www.flashfirejobs.com/en-uk/career-advisor",
             "x-default": "https://www.flashfirejobs.com/career-advisor",
         },
     },

--- a/app/en-ca/contact-us/page.tsx
+++ b/app/en-ca/contact-us/page.tsx
@@ -16,6 +16,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/contact-us",
       "en-CA": "https://www.flashfirejobs.com/en-ca/contact-us",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/contact-us",
       "x-default": "https://www.flashfirejobs.com/contact-us",
     },
   },

--- a/app/en-ca/cv-keyword-scanner/page.tsx
+++ b/app/en-ca/cv-keyword-scanner/page.tsx
@@ -10,6 +10,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/cv-keyword-scanner",
       "en-CA": "https://www.flashfirejobs.com/en-ca/cv-keyword-scanner",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/cv-keyword-scanner",
       "x-default": "https://www.flashfirejobs.com/cv-keyword-scanner",
     },
   },

--- a/app/en-ca/employers/page.tsx
+++ b/app/en-ca/employers/page.tsx
@@ -16,6 +16,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/employers",
       "en-CA": "https://www.flashfirejobs.com/en-ca/employers",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/employers",
       "x-default": "https://www.flashfirejobs.com/employers",
     },
   },

--- a/app/en-ca/faq/page.tsx
+++ b/app/en-ca/faq/page.tsx
@@ -15,6 +15,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/faq",
       "en-CA": "https://www.flashfirejobs.com/en-ca/faq",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/faq",
       "x-default": "https://www.flashfirejobs.com/faq",
     },
   },

--- a/app/en-ca/features/ai-cover-letter-generator/page.tsx
+++ b/app/en-ca/features/ai-cover-letter-generator/page.tsx
@@ -15,6 +15,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/features/ai-cover-letter-generator",
       "en-CA": "https://www.flashfirejobs.com/en-ca/features/ai-cover-letter-generator",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/features/ai-cover-letter-generator",
       "x-default": "https://www.flashfirejobs.com/features/ai-cover-letter-generator",
     },
   },

--- a/app/en-ca/features/ai-job-targeting/page.tsx
+++ b/app/en-ca/features/ai-job-targeting/page.tsx
@@ -15,6 +15,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/features/ai-job-targeting",
       "en-CA": "https://www.flashfirejobs.com/en-ca/features/ai-job-targeting",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/features/ai-job-targeting",
       "x-default": "https://www.flashfirejobs.com/features/ai-job-targeting",
     },
   },

--- a/app/en-ca/features/ats-resume-optimizer/page.tsx
+++ b/app/en-ca/features/ats-resume-optimizer/page.tsx
@@ -15,6 +15,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/features/ats-resume-optimizer",
       "en-CA": "https://www.flashfirejobs.com/en-ca/features/ats-resume-optimizer",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/features/ats-resume-optimizer",
       "x-default": "https://www.flashfirejobs.com/features/ats-resume-optimizer",
     },
   },

--- a/app/en-ca/features/automated-job-applications/page.tsx
+++ b/app/en-ca/features/automated-job-applications/page.tsx
@@ -15,6 +15,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/features/automated-job-applications",
       "en-CA": "https://www.flashfirejobs.com/en-ca/features/automated-job-applications",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/features/automated-job-applications",
       "x-default": "https://www.flashfirejobs.com/features/automated-job-applications",
     },
   },

--- a/app/en-ca/features/cover-letter/page.tsx
+++ b/app/en-ca/features/cover-letter/page.tsx
@@ -15,6 +15,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/features/cover-letter",
       "en-CA": "https://www.flashfirejobs.com/en-ca/features/cover-letter",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/features/cover-letter",
       "x-default": "https://www.flashfirejobs.com/features/cover-letter",
     },
   },

--- a/app/en-ca/features/dashboard-analytics/page.tsx
+++ b/app/en-ca/features/dashboard-analytics/page.tsx
@@ -15,6 +15,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/features/dashboard-analytics",
       "en-CA": "https://www.flashfirejobs.com/en-ca/features/dashboard-analytics",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/features/dashboard-analytics",
       "x-default": "https://www.flashfirejobs.com/features/dashboard-analytics",
     },
   },

--- a/app/en-ca/features/interview-tips/page.tsx
+++ b/app/en-ca/features/interview-tips/page.tsx
@@ -13,6 +13,7 @@ export const metadata: Metadata = {
         languages: {
             "en-US": "https://www.flashfirejobs.com/features/interview-tips",
             "en-CA": "https://www.flashfirejobs.com/en-ca/features/interview-tips",
+            "en-GB": "https://www.flashfirejobs.com/en-uk/features/interview-tips",
             "x-default": "https://www.flashfirejobs.com/features/interview-tips",
         },
     },

--- a/app/en-ca/features/job-application-tracker/page.tsx
+++ b/app/en-ca/features/job-application-tracker/page.tsx
@@ -15,6 +15,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/features/job-application-tracker",
       "en-CA": "https://www.flashfirejobs.com/en-ca/features/job-application-tracker",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/features/job-application-tracker",
       "x-default": "https://www.flashfirejobs.com/features/job-application-tracker",
     },
   },

--- a/app/en-ca/features/job-automation/page.tsx
+++ b/app/en-ca/features/job-automation/page.tsx
@@ -15,6 +15,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/features/job-automation",
       "en-CA": "https://www.flashfirejobs.com/en-ca/features/job-automation",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/features/job-automation",
       "x-default": "https://www.flashfirejobs.com/features/job-automation",
     },
   },

--- a/app/en-ca/features/job-tracker/page.tsx
+++ b/app/en-ca/features/job-tracker/page.tsx
@@ -15,6 +15,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/features/job-tracker",
       "en-CA": "https://www.flashfirejobs.com/en-ca/features/job-tracker",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/features/job-tracker",
       "x-default": "https://www.flashfirejobs.com/features/job-tracker",
     },
   },

--- a/app/en-ca/features/linkedin-profile-optimization-tool/page.tsx
+++ b/app/en-ca/features/linkedin-profile-optimization-tool/page.tsx
@@ -15,6 +15,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/features/linkedin-profile-optimization-tool",
       "en-CA": "https://www.flashfirejobs.com/en-ca/features/linkedin-profile-optimization-tool",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/features/linkedin-profile-optimization-tool",
       "x-default": "https://www.flashfirejobs.com/features/linkedin-profile-optimization-tool",
     },
   },

--- a/app/en-ca/features/linkedin-profile-optimization/page.tsx
+++ b/app/en-ca/features/linkedin-profile-optimization/page.tsx
@@ -15,6 +15,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/features/linkedin-profile-optimization",
       "en-CA": "https://www.flashfirejobs.com/en-ca/features/linkedin-profile-optimization",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/features/linkedin-profile-optimization",
       "x-default": "https://www.flashfirejobs.com/features/linkedin-profile-optimization",
     },
   },

--- a/app/en-ca/features/page.tsx
+++ b/app/en-ca/features/page.tsx
@@ -12,6 +12,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/features",
       "en-CA": "https://www.flashfirejobs.com/en-ca/features",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/features",
       "x-default": "https://www.flashfirejobs.com/features",
     },
   },

--- a/app/en-ca/features/precision-targeting/page.tsx
+++ b/app/en-ca/features/precision-targeting/page.tsx
@@ -15,6 +15,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/features/precision-targeting",
       "en-CA": "https://www.flashfirejobs.com/en-ca/features/precision-targeting",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/features/precision-targeting",
       "x-default": "https://www.flashfirejobs.com/features/precision-targeting",
     },
   },

--- a/app/en-ca/features/resume-optimizer/page.tsx
+++ b/app/en-ca/features/resume-optimizer/page.tsx
@@ -15,6 +15,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/features/resume-optimizer",
       "en-CA": "https://www.flashfirejobs.com/en-ca/features/resume-optimizer",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/features/resume-optimizer",
       "x-default": "https://www.flashfirejobs.com/features/resume-optimizer",
     },
   },

--- a/app/en-ca/get-me-interview/page.tsx
+++ b/app/en-ca/get-me-interview/page.tsx
@@ -15,6 +15,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/get-me-interview",
       "en-CA": "https://www.flashfirejobs.com/en-ca/get-me-interview",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/get-me-interview",
       "x-default": "https://www.flashfirejobs.com/get-me-interview",
     },
   },

--- a/app/en-ca/gross-pay-calculator/page.tsx
+++ b/app/en-ca/gross-pay-calculator/page.tsx
@@ -11,6 +11,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/gross-pay-calculator",
       "en-CA": "https://www.flashfirejobs.com/en-ca/gross-pay-calculator",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/gross-pay-calculator",
       "x-default": "https://www.flashfirejobs.com/gross-pay-calculator",
     },
   },

--- a/app/en-ca/hourly-to-salary-calculator/page.tsx
+++ b/app/en-ca/hourly-to-salary-calculator/page.tsx
@@ -11,6 +11,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/hourly-to-salary-calculator",
       "en-CA": "https://www.flashfirejobs.com/en-ca/hourly-to-salary-calculator",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/hourly-to-salary-calculator",
       "x-default": "https://www.flashfirejobs.com/hourly-to-salary-calculator",
     },
   },

--- a/app/en-ca/how-flashfire-ai-job-automation-platform-works/page.tsx
+++ b/app/en-ca/how-flashfire-ai-job-automation-platform-works/page.tsx
@@ -14,6 +14,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/how-flashfire-ai-job-automation-platform-works",
       "en-CA": "https://www.flashfirejobs.com/en-ca/how-flashfire-ai-job-automation-platform-works",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/how-flashfire-ai-job-automation-platform-works",
       "x-default": "https://www.flashfirejobs.com/how-flashfire-ai-job-automation-platform-works",
     },
   },

--- a/app/en-ca/image-testimonials/page.tsx
+++ b/app/en-ca/image-testimonials/page.tsx
@@ -16,6 +16,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/image-testimonials",
       "en-CA": "https://www.flashfirejobs.com/en-ca/image-testimonials",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/image-testimonials",
       "x-default": "https://www.flashfirejobs.com/image-testimonials",
     },
   },

--- a/app/en-ca/interview-buddy/page.tsx
+++ b/app/en-ca/interview-buddy/page.tsx
@@ -15,6 +15,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/interview-buddy",
       "en-CA": "https://www.flashfirejobs.com/en-ca/interview-buddy",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/interview-buddy",
       "x-default": "https://www.flashfirejobs.com/interview-buddy",
     },
   },

--- a/app/en-ca/job-application-status-tracker/page.tsx
+++ b/app/en-ca/job-application-status-tracker/page.tsx
@@ -12,6 +12,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/job-application-status-tracker",
       "en-CA": "https://www.flashfirejobs.com/en-ca/job-application-status-tracker",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/job-application-status-tracker",
       "x-default": "https://www.flashfirejobs.com/job-application-status-tracker",
     },
   },

--- a/app/en-ca/job-search/page.tsx
+++ b/app/en-ca/job-search/page.tsx
@@ -16,6 +16,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/job-search",
       "en-CA": "https://www.flashfirejobs.com/en-ca/job-search",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/job-search",
       "x-default": "https://www.flashfirejobs.com/job-search",
     },
   },

--- a/app/en-ca/offer-and-salary/page.tsx
+++ b/app/en-ca/offer-and-salary/page.tsx
@@ -15,6 +15,7 @@ export const metadata: Metadata = {
         languages: {
             "en-US": "https://www.flashfirejobs.com/offer-and-salary-negotiation-advisor",
             "en-CA": "https://www.flashfirejobs.com/en-ca/offer-and-salary",
+            "en-GB": "https://www.flashfirejobs.com/en-uk/offer-and-salary",
             "x-default": "https://www.flashfirejobs.com/offer-and-salary-negotiation-advisor",
         },
     },

--- a/app/en-ca/page.tsx
+++ b/app/en-ca/page.tsx
@@ -14,6 +14,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/",
       "en-CA": "https://www.flashfirejobs.com/en-ca",
+      "en-GB": "https://www.flashfirejobs.com/en-uk",
       "x-default": "https://www.flashfirejobs.com/",
     },
   },

--- a/app/en-ca/pricing/page.tsx
+++ b/app/en-ca/pricing/page.tsx
@@ -20,6 +20,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/pricing",
       "en-CA": "https://www.flashfirejobs.com/en-ca/pricing",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/pricing",
       "x-default": "https://www.flashfirejobs.com/pricing",
     },
   },

--- a/app/en-ca/recent-job-openings/page.tsx
+++ b/app/en-ca/recent-job-openings/page.tsx
@@ -14,6 +14,7 @@ export const metadata: Metadata = {
         languages: {
             "en-US": "https://www.flashfirejobs.com/recent-job-openings",
             "en-CA": "https://www.flashfirejobs.com/en-ca/recent-job-openings",
+            "en-GB": "https://www.flashfirejobs.com/en-uk/recent-job-openings",
             "x-default": "https://www.flashfirejobs.com/recent-job-openings",
         },
     },

--- a/app/en-ca/resume-bullet-point-generator/page.tsx
+++ b/app/en-ca/resume-bullet-point-generator/page.tsx
@@ -10,6 +10,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/resume-bullet-point-generator",
       "en-CA": "https://www.flashfirejobs.com/en-ca/resume-bullet-point-generator",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/resume-bullet-point-generator",
       "x-default": "https://www.flashfirejobs.com/resume-bullet-point-generator",
     },
   },

--- a/app/en-ca/resume-headline-generator/page.tsx
+++ b/app/en-ca/resume-headline-generator/page.tsx
@@ -10,6 +10,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/resume-headline-generator",
       "en-CA": "https://www.flashfirejobs.com/en-ca/resume-headline-generator",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/resume-headline-generator",
       "x-default": "https://www.flashfirejobs.com/resume-headline-generator",
     },
   },

--- a/app/en-ca/resume-parser/page.tsx
+++ b/app/en-ca/resume-parser/page.tsx
@@ -10,6 +10,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/resume-parser",
       "en-CA": "https://www.flashfirejobs.com/en-ca/resume-parser",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/resume-parser",
       "x-default": "https://www.flashfirejobs.com/resume-parser",
     },
   },

--- a/app/en-ca/salary-calculator/page.tsx
+++ b/app/en-ca/salary-calculator/page.tsx
@@ -11,6 +11,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/salary-calculator",
       "en-CA": "https://www.flashfirejobs.com/en-ca/salary-calculator",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/salary-calculator",
       "x-default": "https://www.flashfirejobs.com/salary-calculator",
     },
   },

--- a/app/en-ca/salary-comparison/page.tsx
+++ b/app/en-ca/salary-comparison/page.tsx
@@ -11,6 +11,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/salary-comparison",
       "en-CA": "https://www.flashfirejobs.com/en-ca/salary-comparison",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/salary-comparison",
       "x-default": "https://www.flashfirejobs.com/salary-comparison",
     },
   },

--- a/app/en-ca/salary-estimator/page.tsx
+++ b/app/en-ca/salary-estimator/page.tsx
@@ -11,6 +11,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/salary-estimator",
       "en-CA": "https://www.flashfirejobs.com/en-ca/salary-estimator",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/salary-estimator",
       "x-default": "https://www.flashfirejobs.com/salary-estimator",
     },
   },

--- a/app/en-ca/see-flashfire-in-action/page.tsx
+++ b/app/en-ca/see-flashfire-in-action/page.tsx
@@ -15,6 +15,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/see-flashfire-in-action",
       "en-CA": "https://www.flashfirejobs.com/en-ca/see-flashfire-in-action",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/see-flashfire-in-action",
       "x-default": "https://www.flashfirejobs.com/see-flashfire-in-action",
     },
   },

--- a/app/en-ca/take-home-pay-calculator/page.tsx
+++ b/app/en-ca/take-home-pay-calculator/page.tsx
@@ -11,6 +11,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/take-home-pay-calculator",
       "en-CA": "https://www.flashfirejobs.com/en-ca/take-home-pay-calculator",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/take-home-pay-calculator",
       "x-default": "https://www.flashfirejobs.com/take-home-pay-calculator",
     },
   },

--- a/app/en-ca/testimonials/page.tsx
+++ b/app/en-ca/testimonials/page.tsx
@@ -16,6 +16,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/testimonials",
       "en-CA": "https://www.flashfirejobs.com/en-ca/testimonials",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/testimonials",
       "x-default": "https://www.flashfirejobs.com/testimonials",
     },
   },

--- a/app/en-uk/AI-copilot/get-me-interview/page.tsx
+++ b/app/en-uk/AI-copilot/get-me-interview/page.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import GetMeInterviewPage from "@/app/get-me-interview/page";
+
+export default function EnUkAICopilotGetMeInterview() {
+  return <GetMeInterviewPage />;
+}
+

--- a/app/en-uk/AI-copilot/page.tsx
+++ b/app/en-uk/AI-copilot/page.tsx
@@ -1,0 +1,42 @@
+import {Metadata} from "next";
+import AICopilot from "@/src/components/AICopilot/AICopilot";
+import Footer from "@/src/components/footer/footer";
+import Navbar from "@/src/components/navbar/navbar";
+const metadata: Metadata = {
+  title: "AI Copilot: Personalized Interview Tips | Flashfire",
+  description:
+    "Get personalized interview tips based on your skills, experience, and career goals. Our interview buddy is here to help you land your dream job.",
+  robots: {
+    index: true,
+    follow: true,
+  },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-uk/AI-copilot",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/AI-copilot",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/AI-copilot",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/AI-copilot",
+      "x-default": "https://www.flashfirejobs.com/AI-copilot",
+    },
+  },
+  openGraph: {
+    title: "AI Copilot: Personalized Interview Tips | Flashfire",
+    description:
+      "Get personalized interview tips based on your skills, experience, and career goals.",
+    url: "https://www.flashfirejobs.com/en-uk/AI-copilot",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    images: ["https://www.flashfirejobs.com/images/og-image.png"],
+  },
+};
+export default function AIcopilot() {
+  return (
+    <>
+      <Navbar />
+      <AICopilot />
+      <Footer />
+    </>
+  );
+}

--- a/app/en-uk/Get-Started/page.tsx
+++ b/app/en-uk/Get-Started/page.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import HomePage from "@/src/components/pages/home/Home";
+import { useEffect } from "react";
+
+export default function GetStartedPage() {
+    useEffect(() => {
+        // Immediately prevent scroll to top
+        const savedScrollY = sessionStorage.getItem('preserveScrollPosition');
+        if (savedScrollY) {
+            const scrollY = parseInt(savedScrollY, 10);
+            
+            // Prevent scroll immediately
+            window.scrollTo({ top: scrollY, behavior: 'instant' });
+            
+            // Also restore after a short delay to catch any late scrolls
+            const restoreScroll = () => {
+                window.scrollTo({ top: scrollY, behavior: 'instant' });
+            };
+            
+            // Try multiple times to ensure it sticks
+            requestAnimationFrame(() => {
+                restoreScroll();
+                requestAnimationFrame(() => {
+                    restoreScroll();
+                    setTimeout(() => {
+                        restoreScroll();
+                        // Clear the saved position after restoring
+                        sessionStorage.removeItem('preserveScrollPosition');
+                    }, 100);
+                });
+            });
+        }
+    }, []);
+    return <HomePage />;
+}

--- a/app/en-uk/about-us/page.tsx
+++ b/app/en-uk/about-us/page.tsx
@@ -1,0 +1,60 @@
+import { Metadata } from "next";
+import AboutUs from "@/src/components/pages/aboutUs/AboutUs";
+import Footer from "@/src/components/footer/footer";
+import Navbar from "@/src/components/navbar/navbar";
+
+export const metadata: Metadata = {
+  title: "About Flashfire — AI Job Search Automation Platform (UK)",
+  description:
+    "Flashfire is an AI job application service that automates job applications, optimizes resumes, and helps UK job seekers land interviews faster.",
+  robots: {
+    index: true,
+    follow: true,
+  },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-uk/about-us",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/about-us",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/about-us",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/about-us",
+      "x-default": "https://www.flashfirejobs.com/about-us",
+    },
+  },
+  openGraph: {
+    title: "About Flashfire — AI Job Search Automation Platform (UK)",
+    description:
+      "Flashfire is an AI job application service that automates job applications, optimizes resumes, and helps UK job seekers land interviews faster.",
+    url: "https://www.flashfirejobs.com/en-uk/about-us",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "About Flashfire — AI Job Search Automation Platform (UK)",
+    description: "Flashfire is an AI job application service that automates job applications, optimizes resumes, and helps UK job seekers land interviews faster.",
+    images: ["https://www.flashfirejobs.com/images/og-image.png"],
+  },
+};
+
+export default function AboutUsPageUK() {
+  const schema = {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "name": "AI Job Application Service | Job Application Automation (UK)",
+    "url": "https://www.flashfirejobs.com/en-uk/about-us",
+    "description": "Flashfire is an AI job application service that automates job applications, optimizes resumes, and helps UK job seekers land interviews faster.",
+    "publisher": {
+      "@type": "Organization",
+      "name": "Flashfire",
+      "url": "https://www.flashfirejobs.com"
+    }
+  };
+
+  return (
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }} />
+      <Navbar />
+      <AboutUs />
+      <Footer />
+    </>
+  );
+}

--- a/app/en-uk/after-tax-income-calculator/page.tsx
+++ b/app/en-uk/after-tax-income-calculator/page.tsx
@@ -1,0 +1,25 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/after-tax-income-calculator/page";
+
+export const metadata: Metadata = {
+  title: "After Tax Income Calculator – Net Annual Income | Flashfire UK",
+  description: "Estimate your after-tax income by filing status, deductions, tax credits, and provincial tax rate.",
+  robots: { index: true, follow: true },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-uk/after-tax-income-calculator",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/after-tax-income-calculator",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/after-tax-income-calculator",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/after-tax-income-calculator",
+      "x-default": "https://www.flashfirejobs.com/after-tax-income-calculator",
+    },
+  },
+  openGraph: {
+    title: "After Tax Income Calculator – Net Annual Income | Flashfire UK",
+    description: "Estimate your after-tax income by filing status, deductions, tax credits, and provincial tax rate.",
+    url: "https://www.flashfirejobs.com/en-uk/after-tax-income-calculator",
+    type: "website",
+  },
+  twitter: { card: "summary_large_image", images: ["https://www.flashfirejobs.com/images/og-image.png"] },
+};

--- a/app/en-uk/ai-career-assessment-skill-gap-analysis/page.tsx
+++ b/app/en-uk/ai-career-assessment-skill-gap-analysis/page.tsx
@@ -1,0 +1,19 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/ai-career-assessment-skill-gap-analysis/page";
+
+export const metadata: Metadata = {
+  title: "AI Career Assessment & Skill Gap Analysis Tool | Flashfire UK",
+  description:
+    "Run an AI-powered career assessment and skill gap analysis to understand your strengths, weaknesses, and best-fit roles in the UK job market.",
+  robots: { index: true, follow: true },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-uk/ai-career-assessment-skill-gap-analysis",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/ai-career-assessment-skill-gap-analysis",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/ai-career-assessment-skill-gap-analysis",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/ai-career-assessment-skill-gap-analysis",
+      "x-default": "https://www.flashfirejobs.com/ai-career-assessment-skill-gap-analysis",
+    },
+  },
+};

--- a/app/en-uk/ai-follow-up-email-generator/page.tsx
+++ b/app/en-uk/ai-follow-up-email-generator/page.tsx
@@ -1,0 +1,19 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/ai-follow-up-email-generator/page";
+
+export const metadata: Metadata = {
+  title: "AI Follow-Up Email Generator for Job Applications | Flashfire UK",
+  description:
+    "Generate professional, timely follow-up emails for job applications and interviews using Flashfire's AI follow-up email generator.",
+  robots: { index: true, follow: true },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-uk/ai-follow-up-email-generator",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/ai-follow-up-email-generator",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/ai-follow-up-email-generator",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/ai-follow-up-email-generator",
+      "x-default": "https://www.flashfirejobs.com/ai-follow-up-email-generator",
+    },
+  },
+};

--- a/app/en-uk/ai-interview-answer-generator/page.tsx
+++ b/app/en-uk/ai-interview-answer-generator/page.tsx
@@ -1,0 +1,25 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/ai-interview-answer-generator/page";
+
+export const metadata: Metadata = {
+  title: "AI Interview Answer Generator – STAR Format | Flashfire UK",
+  description: "Generate polished STAR-format interview answers from your role, question, and achievement. Personalize and ace your next interview.",
+  robots: { index: true, follow: true },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-uk/ai-interview-answer-generator",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/ai-interview-answer-generator",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/ai-interview-answer-generator",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/ai-interview-answer-generator",
+      "x-default": "https://www.flashfirejobs.com/ai-interview-answer-generator",
+    },
+  },
+  openGraph: {
+    title: "AI Interview Answer Generator – STAR Format | Flashfire UK",
+    description: "Generate polished STAR-format interview answers from your role, question, and achievement. Personalize and ace your next interview.",
+    url: "https://www.flashfirejobs.com/en-uk/ai-interview-answer-generator",
+    type: "website",
+  },
+  twitter: { card: "summary_large_image", images: ["https://www.flashfirejobs.com/images/og-image.png"] },
+};

--- a/app/en-uk/ai-job-alerts/page.tsx
+++ b/app/en-uk/ai-job-alerts/page.tsx
@@ -1,0 +1,19 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/ai-job-alerts/page";
+
+export const metadata: Metadata = {
+  title: "AI Job Alerts & Smart Job Notifications | Flashfire UK",
+  description:
+    "Get AI-powered job alerts and smart notifications so you never miss high-fit roles that match your profile in UK.",
+  robots: { index: true, follow: true },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-uk/ai-job-alerts",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/ai-job-alerts",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/ai-job-alerts",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/ai-job-alerts",
+      "x-default": "https://www.flashfirejobs.com/ai-job-alerts",
+    },
+  },
+};

--- a/app/en-uk/ai-job-matching-platform/page.tsx
+++ b/app/en-uk/ai-job-matching-platform/page.tsx
@@ -1,0 +1,19 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/ai-job-matching-platform/page";
+
+export const metadata: Metadata = {
+  title: "AI Job Matching Platform | Flashfire UK",
+  description:
+    "Flashfire's AI job matching platform connects your skills, experience, and goals with the right roles across the UK market.",
+  robots: { index: true, follow: true },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-uk/ai-job-matching-platform",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/ai-job-matching-platform",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/ai-job-matching-platform",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/ai-job-matching-platform",
+      "x-default": "https://www.flashfirejobs.com/ai-job-matching-platform",
+    },
+  },
+};

--- a/app/en-uk/ai-job-search-platform-for-freshers/page.tsx
+++ b/app/en-uk/ai-job-search-platform-for-freshers/page.tsx
@@ -1,0 +1,25 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/ai-job-search-platform-for-freshers/page";
+
+export const metadata: Metadata = {
+  title: "AI Job Search Platform for Freshers | Flashfire UK",
+  description:
+    "Use Flashfire's AI job search platform for freshers to discover internships and entry-level roles that match your skills and goals in UK.",
+  robots: { index: true, follow: true },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-uk/ai-job-search-platform-for-freshers",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/ai-job-search-platform-for-freshers",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/ai-job-search-platform-for-freshers",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/ai-job-search-platform-for-freshers",
+      "x-default": "https://www.flashfirejobs.com/ai-job-search-platform-for-freshers",
+    },
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "AI Job Search Platform for Freshers — Flashfire UK",
+    description: "Fresh graduate? Flashfire automates your job search so you can apply to hundreds of roles with optimized resumes and get interviews faster.",
+    images: ["https://www.flashfirejobs.com/images/og-image.png"],
+  },
+};

--- a/app/en-uk/ai-remote-job-search-platform/page.tsx
+++ b/app/en-uk/ai-remote-job-search-platform/page.tsx
@@ -1,0 +1,19 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/ai-remote-job-search-platform/page";
+
+export const metadata: Metadata = {
+  title: "AI Remote Job Search Platform | Flashfire UK",
+  description:
+    "Discover remote jobs across UK, US, and global markets with Flashfire's AI-powered remote job search platform.",
+  robots: { index: true, follow: true },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-uk/ai-remote-job-search-platform",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/ai-remote-job-search-platform",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/ai-remote-job-search-platform",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/ai-remote-job-search-platform",
+      "x-default": "https://www.flashfirejobs.com/ai-remote-job-search-platform",
+    },
+  },
+};

--- a/app/en-uk/ai-resume-builder/page.tsx
+++ b/app/en-uk/ai-resume-builder/page.tsx
@@ -1,0 +1,19 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/ai-resume-builder/page";
+
+export const metadata: Metadata = {
+  title: "AI Resume Builder for Job Seekers | Flashfire UK",
+  description:
+    "Use Flashfire's AI resume builder to create ATS-friendly, professional resumes tailored to every job you apply for in UK.",
+  robots: { index: true, follow: true },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-uk/ai-resume-builder",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/ai-resume-builder",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/ai-resume-builder",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/ai-resume-builder",
+      "x-default": "https://www.flashfirejobs.com/ai-resume-builder",
+    },
+  },
+};

--- a/app/en-uk/ai-resume-summary-generator/page.tsx
+++ b/app/en-uk/ai-resume-summary-generator/page.tsx
@@ -1,0 +1,18 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/ai-resume-summary-generator/page";
+
+export const metadata: Metadata = {
+  title: "AI Resume Summary Generator | Flashfire UK",
+  description: "Generate a compelling professional resume summary in seconds. Free AI resume summary generator.",
+  robots: { index: true, follow: true },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-uk/ai-resume-summary-generator",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/ai-resume-summary-generator",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/ai-resume-summary-generator",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/ai-resume-summary-generator",
+      "x-default": "https://www.flashfirejobs.com/ai-resume-summary-generator",
+    },
+  },
+};

--- a/app/en-uk/ats-score-checker/page.tsx
+++ b/app/en-uk/ats-score-checker/page.tsx
@@ -1,0 +1,31 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/ats-score-checker/page";
+
+export const metadata: Metadata = {
+  title: "Free ATS Resume Score Checker | Flashfire UK",
+  description: "Check your resume ATS score instantly. Get detailed feedback and improvement tips. Free ATS score checker.",
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-uk/ats-score-checker",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/ats-score-checker",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/ats-score-checker",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/ats-score-checker",
+      "x-default": "https://www.flashfirejobs.com/ats-score-checker",
+    },
+  },
+  openGraph: {
+    title: "Free ATS Resume Score Checker | Flashfire UK",
+    description: "Check your resume ATS score instantly. Get detailed feedback and improvement tips. Free ATS score checker.",
+    url: "https://www.flashfirejobs.com/en-uk/ats-score-checker",
+    type: "website",
+    images: [
+      {
+        url: "https://www.flashfirejobs.com/images/og-image.png",
+        width: 1200,
+        height: 630,
+        alt: "Flashfire",
+      },
+    ],
+  },
+};

--- a/app/en-uk/blog/page.tsx
+++ b/app/en-uk/blog/page.tsx
@@ -1,0 +1,56 @@
+import { Metadata } from "next";
+import { Suspense } from "react";
+import BlogsClient from "@/src/components/blogs/blogsClient";
+import Footer from "@/src/components/footer/footer";
+import Navbar from "@/src/components/navbar/navbar";
+
+export const metadata: Metadata = {
+  title: "Flashfire Blog: UK Career Tips & Job Advice",
+  description:
+    "Discover expert career tips, job search strategies, resume writing guides, and industry insights to accelerate your job search success.",
+  robots: {
+    index: true,
+    follow: true,
+  },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-uk/blog",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/blog",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/blog",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/blog",
+      "x-default": "https://www.flashfirejobs.com/blog",
+    },
+  },
+  openGraph: {
+    title: "Flashfire Blog: UK Career Tips & Job Advice",
+    description:
+      "Discover expert career tips, job search strategies, and industry insights.",
+    url: "https://www.flashfirejobs.com/en-uk/blog",
+    type: "website",
+    images: [
+      {
+        url: "https://www.flashfirejobs.com/images/og-image.png",
+        width: 1200,
+        height: 630,
+        alt: "FLASHFIRE Logo",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    images: ["https://www.flashfirejobs.com/images/og-image.png"],
+  },
+};
+
+export default function BlogPageUK() {
+  return (
+    <>
+      <Navbar />
+      <Suspense fallback={<div style={{ padding: "6rem 2rem", textAlign: "center" }}>Loading blogs...</div>}>
+        <BlogsClient heading="Career Tips & Job Advice for UK Job Seekers" />
+      </Suspense>
+      <Footer />
+    </>
+  );
+}
+

--- a/app/en-uk/blogs/page.tsx
+++ b/app/en-uk/blogs/page.tsx
@@ -1,0 +1,54 @@
+import { Metadata } from "next";
+import { Suspense } from "react";
+import BlogsClient from "@/src/components/blogs/blogsClient";
+import Footer from "@/src/components/footer/footer";
+import Navbar from "@/src/components/navbar/navbar";
+
+// Force static generation for better performance
+export const dynamic = 'force-static';
+export const revalidate = false;
+
+export const metadata: Metadata = {
+  title: "Flashfire Blog: UK Career Tips & Job Advice",
+  description:
+    "Discover expert career tips, job search strategies, resume writing guides, and industry insights to accelerate your job search success.",
+  robots: {
+    index: true,
+    follow: true,
+  },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-uk/blogs",
+  },
+  openGraph: {
+    title: "Flashfire Blog: UK Career Tips & Job Advice",
+    description:
+      "Discover expert career tips, job search strategies, and industry insights.",
+    url: "https://www.flashfirejobs.com/en-uk/blogs",
+    type: "website",
+    images: [
+      {
+        url: "https://www.flashfirejobs.com/images/og-image.png",
+        width: 1200,
+        height: 630,
+        alt: "FLASHFIRE Logo",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    images: ["https://www.flashfirejobs.com/images/og-image.png"],
+  },
+};
+
+export default function BlogsPageUK() {
+  return (
+    <>
+      <Navbar />
+      <Suspense fallback={<div style={{ padding: "6rem 2rem", textAlign: "center" }}>Loading blogs...</div>}>
+        <BlogsClient />
+      </Suspense>
+      <Footer />
+    </>
+  );
+}
+

--- a/app/en-uk/book-a-demo/page.tsx
+++ b/app/en-uk/book-a-demo/page.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useEffect, useState, useLayoutEffect } from "react";
+import HomePage from "@/src/components/pages/home/Home";
+import AboutUs from "@/src/components/pages/aboutUs/AboutUs";
+import Navbar from "@/src/components/navbar/navbar";
+import Footer from "@/src/components/footer/footer";
+
+
+export default function BookADemoPage() {
+    const [previousPage, setPreviousPage] = useState<string | null>(null);
+    const [isMounted, setIsMounted] = useState(false);
+
+    useLayoutEffect(() => {
+        setIsMounted(true);
+        
+        const savedPreviousPage = sessionStorage.getItem('previousPageBeforeBookADemo');
+        if (savedPreviousPage) {
+            setPreviousPage(savedPreviousPage);
+        }
+        
+        const savedScrollY = sessionStorage.getItem('preserveScrollPosition');
+        if (savedScrollY) {
+            const scrollY = parseInt(savedScrollY, 10);
+            
+            window.scrollTo({ top: scrollY, behavior: 'instant' });
+            
+            const restoreScroll = () => {
+                window.scrollTo({ top: scrollY, behavior: 'instant' });
+            };
+            
+            requestAnimationFrame(() => {
+                restoreScroll();
+                requestAnimationFrame(() => {
+                    restoreScroll();
+                    setTimeout(() => {
+                        restoreScroll();
+                        sessionStorage.removeItem('preserveScrollPosition');
+                    }, 100);
+                });
+            });
+        }
+    }, []);
+
+    if (!isMounted) {
+        return <HomePage />;
+    }
+
+    if (previousPage === '/about-us' || previousPage === '/en-uk/about-us') {
+        return (
+            <>
+                <Navbar />
+                <AboutUs />
+                <Footer />
+            </>
+        );
+    }
+
+    return <HomePage />;
+}

--- a/app/en-uk/career-advisor/page.tsx
+++ b/app/en-uk/career-advisor/page.tsx
@@ -1,0 +1,43 @@
+import { Metadata } from "next";
+import CareerAdvisor from "@/src/components/careerAdvisor/careerAdvisor";
+import Footer from "@/src/components/footer/footer";
+import Navbar from "@/src/components/navbar/navbar";
+export const metadata: Metadata = {
+    title: "AI Career Advisor: Personalized Job Recommendations",
+    description:
+        "Get personalized job recommendations based on your skills, experience, and career goals. Our career advisor is here to help you find the perfect job.",
+    robots: {
+        index: true,
+        follow: true,
+    },
+    alternates: {
+        canonical: "https://www.flashfirejobs.com/en-uk/career-advisor",
+        languages: {
+            "en-US": "https://www.flashfirejobs.com/career-advisor",
+            "en-CA": "https://www.flashfirejobs.com/en-ca/career-advisor",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/career-advisor",
+            "x-default": "https://www.flashfirejobs.com/career-advisor",
+        },
+    },
+    openGraph: {
+        title: "AI Career Advisor: Personalized Job Recommendations",
+        description:
+            "Get personalized job recommendations based on your skills, experience, and career goals.",
+        url: "https://www.flashfirejobs.com/career-advisor",
+        type: "website",
+    },
+    twitter: {
+        card: "summary_large_image",
+        images: ["https://www.flashfirejobs.com/images/og-image.png"],
+    },
+};
+
+export default function CareerAdvisorPage() {
+    return (
+        <>
+            <Navbar />
+            <CareerAdvisor />
+            <Footer />
+        </>
+    );
+}

--- a/app/en-uk/contact-us/page.tsx
+++ b/app/en-uk/contact-us/page.tsx
@@ -1,0 +1,53 @@
+import { Metadata } from "next";
+import ContactUsClient from "@/src/components/contactUs/contactUsClient";
+import Footer from "@/src/components/footer/footer";
+import Navbar from "@/src/components/navbar/navbar";
+
+export const metadata: Metadata = {
+  title: "Contact Flashfire: Get in Touch | Flashfire UK",
+  description:
+    "Have questions about Flashfire? Contact our UK team for support, partnerships, or job search automation inquiries.",
+  robots: {
+    index: true,
+    follow: true,
+  },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-uk/contact-us",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/contact-us",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/contact-us",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/contact-us",
+      "x-default": "https://www.flashfirejobs.com/contact-us",
+    },
+  },
+  openGraph: {
+    title: "Contact Flashfire: Get in Touch | Flashfire UK",
+    description:
+      "Talk to Flashfire’s UK team for support, partnerships, or general questions.",
+    url: "https://www.flashfirejobs.com/en-uk/contact-us",
+    type: "website",
+    images: [
+      {
+        url: "https://www.flashfirejobs.com/images/og-image.png",
+        width: 1200,
+        height: 630,
+        alt: "FLASHFIRE Logo",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    images: ["https://www.flashfirejobs.com/images/og-image.png"],
+  },
+};
+
+export default function ContactUsPageUK() {
+  return (
+    <>
+      <Navbar />
+      <ContactUsClient />
+      <Footer />
+    </>
+  );
+}
+

--- a/app/en-uk/cv-keyword-scanner/page.tsx
+++ b/app/en-uk/cv-keyword-scanner/page.tsx
@@ -1,0 +1,17 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/cv-keyword-scanner/page";
+
+export const metadata: Metadata = {
+  title: "CV Keyword Scanner | Flashfire UK",
+  description: "Scan your resume for missing keywords. Match your CV to job descriptions. Free CV keyword scanner.",
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-uk/cv-keyword-scanner",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/cv-keyword-scanner",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/cv-keyword-scanner",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/cv-keyword-scanner",
+      "x-default": "https://www.flashfirejobs.com/cv-keyword-scanner",
+    },
+  },
+};

--- a/app/en-uk/employers/page.tsx
+++ b/app/en-uk/employers/page.tsx
@@ -1,0 +1,41 @@
+import { Metadata } from "next";
+import EmployerForm from "@/src/components/employers/employerForm";
+import Footer from "@/src/components/footer/footer";
+import Navbar from "@/src/components/navbar/navbar";
+
+export const metadata: Metadata = {
+  title: "Flashfire for Employers: Hire Top Talent Faster",
+  description:
+    "Partner with Flashfire to access pre-screened, qualified candidates. Connect with job seekers actively applying to roles in your industry.",
+  robots: {
+    index: true,
+    follow: true,
+  },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-uk/employers",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/employers",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/employers",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/employers",
+      "x-default": "https://www.flashfirejobs.com/employers",
+    },
+  },
+  openGraph: {
+    title: "Flashfire for Employers: Hire Top Talent Faster",
+    description:
+      "Partner with Flashfire to access pre-screened, qualified candidates.",
+    url: "https://www.flashfirejobs.com/en-uk/employers",
+    type: "website",
+  },
+};
+
+export default function EmployersPageUK() {
+  return (
+    <>
+      <Navbar />
+      <EmployerForm />
+      <Footer />
+    </>
+  );
+}
+

--- a/app/en-uk/faq/page.tsx
+++ b/app/en-uk/faq/page.tsx
@@ -1,0 +1,127 @@
+import { Metadata } from "next";
+import UKHome from "@/src/components/countries/uk/Home";
+import ScrollToSection from "@/src/utils/ui/scrollToSection";
+
+export const metadata: Metadata = {
+  title: "Flashfire FAQs: AI Job Search Questions Answered",
+  description:
+    "Find answers to common questions about Flashfire's job search automation service, pricing, how it works, and more.",
+  robots: {
+    index: true,
+    follow: true,
+  },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-uk/faq",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/faq",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/faq",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/faq",
+      "x-default": "https://www.flashfirejobs.com/faq",
+    },
+  },
+  openGraph: {
+    title: "Flashfire FAQs: AI Job Search Questions Answered",
+    description:
+      "Find answers to common questions about Flashfire's job search automation.",
+    url: "https://www.flashfirejobs.com/en-uk/faq",
+    type: "website",
+  },
+};
+
+export default function FAQPageUK() {
+  const schema = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "Why are we the best job hunting site to find opportunities quickly?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Because we don't just show jobs — we apply to them for you. You skip browsing, resume editing, and forms. We do it all."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "How does an AI-powered job search improve my chances of finding relevant positions?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "AI-powered job search uses intelligent matching, resume optimization, and automation to apply only to roles that fit your profile. Flashfire's AI-powered job search ensures higher relevance and better recruiter response rates."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Can AI job application tools help me apply for jobs faster?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Yes. Job search automation allows AI to apply for jobs automatically on your behalf, saving time while increasing application volume and accuracy."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What are the benefits of using AI for job search on FlashFireJobs?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Using AI for job search on FlashFireJobs offers several benefits, including personalized job recommendations, faster applications, and improved recruiter visibility. As an AI-powered job search platform, FlashFireJobs combines intelligent job discovery, AI resume matching, and automated applications to help modern job seekers find opportunities quickly and apply with confidence."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Does FlashFireJobs act as an AI job board?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Flashfire works as an AI job search platform, combining job discovery, AI job matching, and automated applications."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "How does an AI-powered job search differ from traditional job searching?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Traditional job searching is manual and time-consuming. AI-powered job search automates resume matching, job applications, and tracking, making job search automation faster and more effective."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What is a job search virtual assistant and how can it make job hunting easier?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "FlashFireJobs acts as your virtual assistant and team — finding jobs, optimizing your resume, and applying for you every day."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Can FlashFireJobs auto apply to jobs on my behalf?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Yes. Flashfire is an AI job application platform that can auto-apply to jobs using AI-driven resume matching and role-specific optimization."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What job application assistance features does FlashFireJobs offer?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "✔️ Resume optimization ✔️ Cover letter submission ✔️ 1,200+ manual applications ✔️ LinkedIn profile tips ✔️ Live job tracker ✔️ WhatsApp support ✔️ Weekly progress updates"
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Which is the best app to find job opportunities in my field?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "FlashFireJobs is ideal if you want results. We don't show jobs — we apply to them with tailored resumes and real human effort."
+        }
+      }
+    ]
+  };
+
+  return (
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }} />
+      <UKHome />
+      <ScrollToSection targetId="faq" />
+    </>
+  );
+}
+

--- a/app/en-uk/feature/page.tsx
+++ b/app/en-uk/feature/page.tsx
@@ -1,0 +1,33 @@
+import { Metadata } from "next";
+import UKHome from "@/src/components/countries/uk/Home";
+import ScrollToSection from "@/src/utils/ui/scrollToSection";
+
+export const metadata: Metadata = {
+  title: "Features - AI-Powered Job Search Automation | Flashfire",
+  description:
+    "Discover Flashfire's powerful features: automated job applications, AI resume tailoring, real-time tracking, and more to accelerate your job search.",
+  robots: {
+    index: true,
+    follow: true,
+  },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-uk/feature",
+  },
+  openGraph: {
+    title: "Features - AI-Powered Job Search Automation",
+    description:
+      "Discover Flashfire's powerful features for automated job search.",
+    url: "https://www.flashfirejobs.com/en-uk/feature",
+    type: "website",
+  },
+};
+
+export default function FeaturePageUK() {
+  return (
+    <>
+      <UKHome />
+      <ScrollToSection targetId="feature" />
+    </>
+  );
+}
+

--- a/app/en-uk/features/ai-cover-letter-generator/page.tsx
+++ b/app/en-uk/features/ai-cover-letter-generator/page.tsx
@@ -1,0 +1,41 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/features/ai-cover-letter-generator/page";
+
+export const metadata: Metadata = {
+  title: "AI Cover Letter Builder for ATS-Friendly Job Applications | Flashfire UK",
+  description:
+    "Flashfire's AI cover letter builder helps UK job seekers generate job-specific, ATS-friendly cover letters in minutes using AI-powered customization.",
+  robots: {
+    index: true,
+    follow: true,
+  },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-uk/features/ai-cover-letter-generator",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/features/ai-cover-letter-generator",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/features/ai-cover-letter-generator",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/features/ai-cover-letter-generator",
+      "x-default": "https://www.flashfirejobs.com/features/ai-cover-letter-generator",
+    },
+  },
+  openGraph: {
+    title: "AI Cover Letter Builder for ATS-Friendly Job Applications | Flashfire UK",
+    description:
+      "Generate job-specific, ATS-friendly cover letters in minutes with Flashfire's AI-powered customization, built for UK job seekers.",
+    url: "https://www.flashfirejobs.com/en-uk/features/ai-cover-letter-generator",
+    type: "website",
+    images: [
+      {
+        url: "https://www.flashfirejobs.com/images/og-image.png",
+        width: 1200,
+        height: 630,
+        alt: "FLASHFIRE Logo",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    images: ["https://www.flashfirejobs.com/images/og-image.png"],
+  },
+};

--- a/app/en-uk/features/ai-job-targeting/page.tsx
+++ b/app/en-uk/features/ai-job-targeting/page.tsx
@@ -1,0 +1,41 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/features/ai-job-targeting/page";
+
+export const metadata: Metadata = {
+  title: "AI Precision Job Targeting for Faster Interview Calls | Flashfire UK",
+  description:
+    "Apply to jobs that actually match your profile. FlashFire's AI targets jobs where your skills, experience, and ATS score give UK job seekers the highest chance of interviews.",
+  robots: {
+    index: true,
+    follow: true,
+  },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-uk/features/ai-job-targeting",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/features/ai-job-targeting",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/features/ai-job-targeting",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/features/ai-job-targeting",
+      "x-default": "https://www.flashfirejobs.com/features/ai-job-targeting",
+    },
+  },
+  openGraph: {
+    title: "AI Precision Job Targeting for Faster Interview Calls | Flashfire UK",
+    description:
+      "FlashFire's AI targets jobs where your skills, experience, and ATS score give you the highest chance of interviews in UK.",
+    url: "https://www.flashfirejobs.com/en-uk/features/ai-job-targeting",
+    type: "website",
+    images: [
+      {
+        url: "https://www.flashfirejobs.com/images/og-image.png",
+        width: 1200,
+        height: 630,
+        alt: "FLASHFIRE Logo",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    images: ["https://www.flashfirejobs.com/images/og-image.png"],
+  },
+};

--- a/app/en-uk/features/ats-resume-optimizer/page.tsx
+++ b/app/en-uk/features/ats-resume-optimizer/page.tsx
@@ -1,0 +1,41 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/features/ats-resume-optimizer/page";
+
+export const metadata: Metadata = {
+  title: "ATS Resume Optimizer & Builder | Flashfire UK",
+  description:
+    "Optimize your resume for each job you apply to. Flashfire aligns your experience with every JD so UK recruiters and ATS systems say yes.",
+  robots: {
+    index: true,
+    follow: true,
+  },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-uk/features/ats-resume-optimizer",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/features/ats-resume-optimizer",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/features/ats-resume-optimizer",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/features/ats-resume-optimizer",
+      "x-default": "https://www.flashfirejobs.com/features/ats-resume-optimizer",
+    },
+  },
+  openGraph: {
+    title: "ATS Resume Optimizer & Builder | Flashfire UK",
+    description:
+      "Automatically tailor your resume to each job description and pass every ATS filter with Flashfire.",
+    url: "https://www.flashfirejobs.com/en-uk/features/ats-resume-optimizer",
+    type: "website",
+    images: [
+      {
+        url: "https://www.flashfirejobs.com/images/og-image.png",
+        width: 1200,
+        height: 630,
+        alt: "FLASHFIRE Logo",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    images: ["https://www.flashfirejobs.com/images/og-image.png"],
+  },
+};

--- a/app/en-uk/features/automated-job-applications/page.tsx
+++ b/app/en-uk/features/automated-job-applications/page.tsx
@@ -1,0 +1,41 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/features/automated-job-applications/page";
+
+export const metadata: Metadata = {
+  title: "Job Application Automation Tool | AI Job Applications | Flashfire UK",
+  description:
+    "Flashfire is an AI job application automation tool that helps UK job seekers automate job applications, beat ATS filters, and land interviews faster.",
+  robots: {
+    index: true,
+    follow: true,
+  },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-uk/features/automated-job-applications",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/features/automated-job-applications",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/features/automated-job-applications",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/features/automated-job-applications",
+      "x-default": "https://www.flashfirejobs.com/features/automated-job-applications",
+    },
+  },
+  openGraph: {
+    title: "Job Application Automation Tool | AI Job Applications | Flashfire UK",
+    description:
+      "Automate job applications, beat ATS filters, and land interviews faster with Flashfire's AI job application automation tool.",
+    url: "https://www.flashfirejobs.com/en-uk/features/automated-job-applications",
+    type: "website",
+    images: [
+      {
+        url: "https://www.flashfirejobs.com/images/og-image.png",
+        width: 1200,
+        height: 630,
+        alt: "FLASHFIRE Logo",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    images: ["https://www.flashfirejobs.com/images/og-image.png"],
+  },
+};

--- a/app/en-uk/features/cover-letter/page.tsx
+++ b/app/en-uk/features/cover-letter/page.tsx
@@ -1,0 +1,42 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/features/cover-letter/page";
+
+export const metadata: Metadata = {
+  title: "AI Cover Letter Builder | Flashfire UK",
+  description:
+    "Generate personalized cover letters tailored to each UK role without writing from scratch. Flashfire keeps tone, proof, and keywords on point.",
+  robots: {
+    index: true,
+    follow: true,
+  },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-uk/features/cover-letter",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/features/cover-letter",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/features/cover-letter",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/features/cover-letter",
+      "x-default": "https://www.flashfirejobs.com/features/cover-letter",
+    },
+  },
+  openGraph: {
+    title: "AI Cover Letter Builder | Flashfire UK",
+    description:
+      "Craft compelling cover letters fast using Flashfire’s AI + human review workflow designed for UK employers.",
+    url: "https://www.flashfirejobs.com/en-uk/features/cover-letter",
+    type: "website",
+    images: [
+      {
+        url: "https://www.flashfirejobs.com/images/og-image.png",
+        width: 1200,
+        height: 630,
+        alt: "FLASHFIRE Logo",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    images: ["https://www.flashfirejobs.com/images/og-image.png"],
+  },
+};
+

--- a/app/en-uk/features/dashboard-analytics/page.tsx
+++ b/app/en-uk/features/dashboard-analytics/page.tsx
@@ -1,0 +1,42 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/features/dashboard-analytics/page";
+
+export const metadata: Metadata = {
+  title: "Job Application Dashboard & Analytics | Flashfire UK",
+  description:
+    "See every UK application, pipeline stage, and conversion metric in one analytics dashboard so you always know what's next.",
+  robots: {
+    index: true,
+    follow: true,
+  },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-uk/features/dashboard-analytics",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/features/dashboard-analytics",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/features/dashboard-analytics",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/features/dashboard-analytics",
+      "x-default": "https://www.flashfirejobs.com/features/dashboard-analytics",
+    },
+  },
+  openGraph: {
+    title: "Job Application Dashboard & Analytics | Flashfire UK",
+    description:
+      "Track applications, interviews, and wins through Flashfire’s live analytics dashboard built for job seekers.",
+    url: "https://www.flashfirejobs.com/en-uk/features/dashboard-analytics",
+    type: "website",
+    images: [
+      {
+        url: "https://www.flashfirejobs.com/images/og-image.png",
+        width: 1200,
+        height: 630,
+        alt: "FLASHFIRE Logo",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    images: ["https://www.flashfirejobs.com/images/og-image.png"],
+  },
+};
+

--- a/app/en-uk/features/interview-tips/page.tsx
+++ b/app/en-uk/features/interview-tips/page.tsx
@@ -1,0 +1,38 @@
+import { Metadata } from "next";
+export { default } from "@/app/features/interview-tips/page";
+
+export const metadata: Metadata = {
+    title: "Interview Tips for UK Job Seekers | Flashfire",
+    description: "Interview Tips - Flashfire",
+    robots: {
+        index: true,
+        follow: true,
+    },
+    alternates: {
+        canonical: "https://www.flashfirejobs.com/en-uk/features/interview-tips",
+        languages: {
+            "en-US": "https://www.flashfirejobs.com/features/interview-tips",
+            "en-CA": "https://www.flashfirejobs.com/en-ca/features/interview-tips",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/features/interview-tips",
+            "x-default": "https://www.flashfirejobs.com/features/interview-tips",
+        },
+    },
+    openGraph: {
+        title: "Interview Tips for UK Job Seekers | Flashfire",
+        description: "Interview Tips - Flashfire",
+        url: "https://www.flashfirejobs.com/en-uk/features/interview-tips",
+        siteName: "Flashfire",
+        images: [
+            { url: "https://www.flashfirejobs.com/og-image.png" },
+        ],
+    },
+    twitter: {
+        card: "summary_large_image",
+        title: "Interview Tips for UK Job Seekers | Flashfire",
+        description: "Interview Tips - Flashfire",
+        images: [
+            { url: "https://www.flashfirejobs.com/og-image.png" },
+        ],
+    },
+}
+ 

--- a/app/en-uk/features/job-application-tracker/page.tsx
+++ b/app/en-uk/features/job-application-tracker/page.tsx
@@ -1,0 +1,41 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/features/job-application-tracker/page";
+
+export const metadata: Metadata = {
+  title: "Job Application Tracker to Track Job Applications | Flashfire UK",
+  description:
+    "Track job applications in one place with FlashFire's job application tracker. Organize jobs, monitor interviews, and optimize your UK job search faster.",
+  robots: {
+    index: true,
+    follow: true,
+  },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-uk/features/job-application-tracker",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/features/job-application-tracker",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/features/job-application-tracker",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/features/job-application-tracker",
+      "x-default": "https://www.flashfirejobs.com/features/job-application-tracker",
+    },
+  },
+  openGraph: {
+    title: "Job Application Tracker to Track Job Applications | Flashfire UK",
+    description:
+      "Organize jobs, monitor interviews, and optimize your job search faster with FlashFire's job application tracker.",
+    url: "https://www.flashfirejobs.com/en-uk/features/job-application-tracker",
+    type: "website",
+    images: [
+      {
+        url: "https://www.flashfirejobs.com/images/og-image.png",
+        width: 1200,
+        height: 630,
+        alt: "FLASHFIRE Logo",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    images: ["https://www.flashfirejobs.com/images/og-image.png"],
+  },
+};

--- a/app/en-uk/features/job-automation/page.tsx
+++ b/app/en-uk/features/job-automation/page.tsx
@@ -1,0 +1,42 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/features/job-automation/page";
+
+export const metadata: Metadata = {
+  title: "Automated Job Applications: Apply to 1000+ Roles",
+  description:
+    "Flashfire sources high-fit UK roles, tailors your assets, and applies on your behalf so you land interviews while saving 150+ hours.",
+  robots: {
+    index: true,
+    follow: true,
+  },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-uk/features/job-automation",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/features/job-automation",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/features/job-automation",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/features/job-automation",
+      "x-default": "https://www.flashfirejobs.com/features/job-automation",
+    },
+  },
+  openGraph: {
+    title: "Automated Job Applications: Apply to 1000+ Roles",
+    description:
+      "Scale your job hunt with human-powered, AI-assisted application automation purpose-built for UK job seekers.",
+    url: "https://www.flashfirejobs.com/en-uk/features/job-automation",
+    type: "website",
+    images: [
+      {
+        url: "https://www.flashfirejobs.com/images/og-image.png",
+        width: 1200,
+        height: 630,
+        alt: "FLASHFIRE Logo",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    images: ["https://www.flashfirejobs.com/images/og-image.png"],
+  },
+};
+

--- a/app/en-uk/features/job-tracker/page.tsx
+++ b/app/en-uk/features/job-tracker/page.tsx
@@ -1,0 +1,42 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/features/job-tracker/page";
+
+export const metadata: Metadata = {
+  title: "Real-Time AI Job Tracker Dashboard | Flashfire UK",
+  description:
+    "Monitor every UK application in one live dashboard with status updates, recruiter notes, and reminders so nothing slips.",
+  robots: {
+    index: true,
+    follow: true,
+  },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-uk/features/job-tracker",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/features/job-tracker",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/features/job-tracker",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/features/job-tracker",
+      "x-default": "https://www.flashfirejobs.com/features/job-tracker",
+    },
+  },
+  openGraph: {
+    title: "Real-Time AI Job Tracker Dashboard | Flashfire UK",
+    description:
+      "Track submissions, interviews, and outcomes across every job Flashfire applies to on your behalf.",
+    url: "https://www.flashfirejobs.com/en-uk/features/job-tracker",
+    type: "website",
+    images: [
+      {
+        url: "https://www.flashfirejobs.com/images/og-image.png",
+        width: 1200,
+        height: 630,
+        alt: "FLASHFIRE Logo",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    images: ["https://www.flashfirejobs.com/images/og-image.png"],
+  },
+};
+

--- a/app/en-uk/features/linkedin-profile-optimization-tool/page.tsx
+++ b/app/en-uk/features/linkedin-profile-optimization-tool/page.tsx
@@ -1,0 +1,41 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/features/linkedin-profile-optimization-tool/page";
+
+export const metadata: Metadata = {
+  title: "LinkedIn Profile Optimization for Recruiter Visibility | Flashfire UK",
+  description:
+    "Optimize your LinkedIn profile to boost recruiter visibility. FlashFire optimizes your LinkedIn to rank higher in recruiter searches and get more interview messages in UK.",
+  robots: {
+    index: true,
+    follow: true,
+  },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-uk/features/linkedin-profile-optimization-tool",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/features/linkedin-profile-optimization-tool",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/features/linkedin-profile-optimization-tool",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/features/linkedin-profile-optimization-tool",
+      "x-default": "https://www.flashfirejobs.com/features/linkedin-profile-optimization-tool",
+    },
+  },
+  openGraph: {
+    title: "LinkedIn Profile Optimization for Recruiter Visibility | Flashfire UK",
+    description:
+      "Rank higher in recruiter searches and get more interview messages with Flashfire's LinkedIn profile optimization.",
+    url: "https://www.flashfirejobs.com/en-uk/features/linkedin-profile-optimization-tool",
+    type: "website",
+    images: [
+      {
+        url: "https://www.flashfirejobs.com/images/og-image.png",
+        width: 1200,
+        height: 630,
+        alt: "FLASHFIRE Logo",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    images: ["https://www.flashfirejobs.com/images/og-image.png"],
+  },
+};

--- a/app/en-uk/features/linkedin-profile-optimization/page.tsx
+++ b/app/en-uk/features/linkedin-profile-optimization/page.tsx
@@ -1,0 +1,42 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/features/linkedin-profile-optimization/page";
+
+export const metadata: Metadata = {
+  title: "LinkedIn Optimization for UK Recruiters",
+  description:
+    "Refresh your LinkedIn profile with recruiter-ready headlines, summaries, and keywords so UK hiring teams can find and trust you faster.",
+  robots: {
+    index: true,
+    follow: true,
+  },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-uk/features/linkedin-profile-optimization",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/features/linkedin-profile-optimization",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/features/linkedin-profile-optimization",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/features/linkedin-profile-optimization",
+      "x-default": "https://www.flashfirejobs.com/features/linkedin-profile-optimization",
+    },
+  },
+  openGraph: {
+    title: "LinkedIn Optimization for UK Recruiters",
+    description:
+      "Polish your LinkedIn presence with ATS-aligned keywords, proof-backed bullets, and an irresistible summary tailored for UK.",
+    url: "https://www.flashfirejobs.com/en-uk/features/linkedin-profile-optimization",
+    type: "website",
+    images: [
+      {
+        url: "https://www.flashfirejobs.com/images/og-image.png",
+        width: 1200,
+        height: 630,
+        alt: "FLASHFIRE Logo",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    images: ["https://www.flashfirejobs.com/images/og-image.png"],
+  },
+};
+

--- a/app/en-uk/features/page.tsx
+++ b/app/en-uk/features/page.tsx
@@ -1,0 +1,32 @@
+import { Metadata } from "next";
+import Navbar from "@/src/components/navbar/navbar";
+import Footer from "@/src/components/footer/footer";
+import Features from "@/src/components/pages/features/Features";
+
+export const metadata: Metadata = {
+  title: "Flashfire Features: Why Choose Our AI Job Search Tool",
+  description:
+    "Explore Flashfire's key features: AI-powered matching, dynamic resume optimization, LinkedIn optimization, precision targeting, and more.",
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-uk/features",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/features",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/features",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/features",
+      "x-default": "https://www.flashfirejobs.com/features",
+    },
+  },
+};
+
+export default function FeaturesPageUK() {
+  return (
+    <div className="bg-white text-black min-h-screen">
+      <Navbar />
+      <main className="mt-0">
+        <Features />
+      </main>
+      <Footer />
+    </div>
+  );
+}
+

--- a/app/en-uk/features/precision-targeting/page.tsx
+++ b/app/en-uk/features/precision-targeting/page.tsx
@@ -1,0 +1,42 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/features/precision-targeting/page";
+
+export const metadata: Metadata = {
+  title: "Precision Job Targeting: Find UK Roles",
+  description:
+    "Flashfire pinpoints roles that match your visa status, salary goals, and tech stack so every application is high intent.",
+  robots: {
+    index: true,
+    follow: true,
+  },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-uk/features/precision-targeting",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/features/precision-targeting",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/features/precision-targeting",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/features/precision-targeting",
+      "x-default": "https://www.flashfirejobs.com/features/precision-targeting",
+    },
+  },
+  openGraph: {
+    title: "Precision Job Targeting: Find UK Roles",
+    description:
+      "Use Flashfire’s targeting engine to surface UK roles aligned to your background, visa, and compensation needs.",
+    url: "https://www.flashfirejobs.com/en-uk/features/precision-targeting",
+    type: "website",
+    images: [
+      {
+        url: "https://www.flashfirejobs.com/images/og-image.png",
+        width: 1200,
+        height: 630,
+        alt: "FLASHFIRE Logo",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    images: ["https://www.flashfirejobs.com/images/og-image.png"],
+  },
+};
+

--- a/app/en-uk/features/resume-optimizer/page.tsx
+++ b/app/en-uk/features/resume-optimizer/page.tsx
@@ -1,0 +1,42 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/features/resume-optimizer/page";
+
+export const metadata: Metadata = {
+  title: "ATS Resume Optimizer & Builder | Flashfire UK",
+  description:
+    "Optimize your resume for each job you apply to. Flashfire aligns your experience with every JD so UK recruiters and ATS systems say yes.",
+  robots: {
+    index: true,
+    follow: true,
+  },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-uk/features/resume-optimizer",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/features/resume-optimizer",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/features/resume-optimizer",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/features/resume-optimizer",
+      "x-default": "https://www.flashfirejobs.com/features/resume-optimizer",
+    },
+  },
+  openGraph: {
+    title: "ATS Resume Optimizer & Builder | Flashfire UK",
+    description:
+      "Automatically tailor your resume to each job description and pass every ATS filter with Flashfire.",
+    url: "https://www.flashfirejobs.com/en-uk/features/resume-optimizer",
+    type: "website",
+    images: [
+      {
+        url: "https://www.flashfirejobs.com/images/og-image.png",
+        width: 1200,
+        height: 630,
+        alt: "FLASHFIRE Logo",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    images: ["https://www.flashfirejobs.com/images/og-image.png"],
+  },
+};
+

--- a/app/en-uk/get-me-interview/page.tsx
+++ b/app/en-uk/get-me-interview/page.tsx
@@ -1,0 +1,42 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/get-me-interview/page";
+
+export const metadata: Metadata = {
+  title: "Get Me an Interview | Flashfire UK",
+  description:
+    "Unlock Flashfire’s human-powered, AI-assisted job search system built for UK job seekers. Track every application and land interviews faster.",
+  robots: {
+    index: true,
+    follow: true,
+  },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-uk/get-me-interview",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/get-me-interview",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/get-me-interview",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/get-me-interview",
+      "x-default": "https://www.flashfirejobs.com/get-me-interview",
+    },
+  },
+  openGraph: {
+    title: "Get Me an Interview | Flashfire UK",
+    description:
+      "Activate Flashfire’s end-to-end job application engine: resume tailoring, job automation, tracking, and updates—all for UK.",
+    url: "https://www.flashfirejobs.com/en-uk/get-me-interview",
+    type: "website",
+    images: [
+      {
+        url: "https://www.flashfirejobs.com/images/og-image.png",
+        width: 1200,
+        height: 630,
+        alt: "FLASHFIRE Logo",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    images: ["https://www.flashfirejobs.com/images/og-image.png"],
+  },
+};
+

--- a/app/en-uk/gross-pay-calculator/page.tsx
+++ b/app/en-uk/gross-pay-calculator/page.tsx
@@ -1,0 +1,25 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/gross-pay-calculator/page";
+
+export const metadata: Metadata = {
+  title: "Gross Pay Calculator – Weekly, Monthly & Annual | Flashfire UK",
+  description: "Calculate gross pay before taxes from hourly rate, regular hours, overtime, and annual bonus.",
+  robots: { index: true, follow: true },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-uk/gross-pay-calculator",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/gross-pay-calculator",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/gross-pay-calculator",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/gross-pay-calculator",
+      "x-default": "https://www.flashfirejobs.com/gross-pay-calculator",
+    },
+  },
+  openGraph: {
+    title: "Gross Pay Calculator – Weekly, Monthly & Annual | Flashfire UK",
+    description: "Calculate gross pay before taxes from hourly rate, regular hours, overtime, and annual bonus.",
+    url: "https://www.flashfirejobs.com/en-uk/gross-pay-calculator",
+    type: "website",
+  },
+  twitter: { card: "summary_large_image", images: ["https://www.flashfirejobs.com/images/og-image.png"] },
+};

--- a/app/en-uk/hourly-to-salary-calculator/page.tsx
+++ b/app/en-uk/hourly-to-salary-calculator/page.tsx
@@ -1,0 +1,25 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/hourly-to-salary-calculator/page";
+
+export const metadata: Metadata = {
+  title: "Hourly to Salary Calculator – Convert Hourly Pay | Flashfire UK",
+  description: "Convert your hourly wage to annual salary instantly. Includes overtime and weeks-per-year inputs.",
+  robots: { index: true, follow: true },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-uk/hourly-to-salary-calculator",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/hourly-to-salary-calculator",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/hourly-to-salary-calculator",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/hourly-to-salary-calculator",
+      "x-default": "https://www.flashfirejobs.com/hourly-to-salary-calculator",
+    },
+  },
+  openGraph: {
+    title: "Hourly to Salary Calculator – Convert Hourly Pay | Flashfire UK",
+    description: "Convert your hourly wage to annual salary instantly. Includes overtime and weeks-per-year inputs.",
+    url: "https://www.flashfirejobs.com/en-uk/hourly-to-salary-calculator",
+    type: "website",
+  },
+  twitter: { card: "summary_large_image", images: ["https://www.flashfirejobs.com/images/og-image.png"] },
+};

--- a/app/en-uk/how-flashfire-ai-job-automation-platform-works/page.tsx
+++ b/app/en-uk/how-flashfire-ai-job-automation-platform-works/page.tsx
@@ -1,0 +1,33 @@
+import { Metadata } from "next";
+import HowItWorks from "@/src/components/pages/howItWorks/HowItWorks";
+
+export const metadata: Metadata = {
+  title: "How It Works: Student Job Search Automation",
+  description:
+    "See how Flashfire gets international students interview calls faster: visa-aware matching, ATS-ready resumes, automated applications, tracking, and interview prep.",
+  robots: {
+    index: true,
+    follow: true,
+  },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-uk/how-flashfire-ai-job-automation-platform-works",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/how-flashfire-ai-job-automation-platform-works",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/how-flashfire-ai-job-automation-platform-works",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/how-flashfire-ai-job-automation-platform-works",
+      "x-default": "https://www.flashfirejobs.com/how-flashfire-ai-job-automation-platform-works",
+    },
+  },
+  openGraph: {
+    title: "How It Works: Student Job Search Automation",
+    description:
+      "Understand how Flashfire automates sourcing, tailoring, and submitting applications so students land interviews faster.",
+    url: "https://www.flashfirejobs.com/en-uk/how-flashfire-ai-job-automation-platform-works",
+    type: "website",
+  },
+};
+
+export default function HowItWorksPage() {
+  return <HowItWorks />;
+}
+

--- a/app/en-uk/how-it-works/page.tsx
+++ b/app/en-uk/how-it-works/page.tsx
@@ -1,0 +1,26 @@
+import { Metadata } from "next";
+import HowItWorks from "@/src/components/pages/howItWorks/HowItWorks";
+
+export const metadata: Metadata = {
+  title: "How It Works: Student Job Search Automation",
+  description:
+    "See how Flashfire gets international students interview calls faster: visa-aware matching, ATS-ready resumes, automated applications, tracking, and interview prep.",
+  robots: {
+    index: true,
+    follow: true,
+  },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-uk/how-it-works",
+  },
+  openGraph: {
+    title: "How It Works: Student Job Search Automation",
+    description:
+      "Understand how Flashfire automates sourcing, tailoring, and submitting applications so students land interviews faster.",
+    url: "https://www.flashfirejobs.com/en-uk/how-it-works",
+    type: "website",
+  },
+};
+
+export default function HowItWorksPage() {
+  return <HowItWorks />;
+}

--- a/app/en-uk/image-testimonials/page.tsx
+++ b/app/en-uk/image-testimonials/page.tsx
@@ -1,0 +1,41 @@
+import { Metadata } from "next";
+import Navbar from "@/src/components/navbar/navbar";
+import Footer from "@/src/components/footer/footer";
+import HappyUsersGalleryPage from "@/src/components/homePageHappyUsers/HappyUsersGalleryPage";
+
+export const metadata: Metadata = {
+  title: "Flashfire Reviews: Success Stories & Testimonials",
+  description:
+    "See real success stories from job seekers who landed their dream jobs with Flashfire. Read testimonials from professionals who automated their job search and saved 150+ hours.",
+  robots: {
+    index: true,
+    follow: true,
+  },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-uk/image-testimonials",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/image-testimonials",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/image-testimonials",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/image-testimonials",
+      "x-default": "https://www.flashfirejobs.com/image-testimonials",
+    },
+  },
+  openGraph: {
+    title: "Flashfire Reviews: Success Stories & Testimonials",
+    description:
+      "See real success stories from job seekers who landed their dream jobs with Flashfire.",
+    url: "https://www.flashfirejobs.com/en-uk/image-testimonials",
+    type: "website",
+  },
+};
+
+export default function ImageTestimonialsPage() {
+  return (
+    <>
+      <Navbar />
+      <HappyUsersGalleryPage />
+      <Footer />
+    </>
+  );
+}
+

--- a/app/en-uk/interview-buddy/page.tsx
+++ b/app/en-uk/interview-buddy/page.tsx
@@ -1,0 +1,33 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/interview-buddy/page";
+
+export const metadata: Metadata = {
+  title: "AI Interview Assistant for Real-Time Support | Flashfire UK",
+  description:
+    "Get real-time AI support during interviews with Flashfire's AI interview assistant. Receive instant answers, live transcripts, and role-specific guidance.",
+  robots: {
+    index: true,
+    follow: true,
+  },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-uk/interview-buddy",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/interview-buddy",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/interview-buddy",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/interview-buddy",
+      "x-default": "https://www.flashfirejobs.com/interview-buddy",
+    },
+  },
+  openGraph: {
+    title: "AI Interview Assistant for Real-Time Support | Flashfire UK",
+    description:
+      "Get real-time AI support during interviews with Flashfire's AI interview assistant. Receive instant answers, live transcripts, and role-specific guidance.",
+    url: "https://www.flashfirejobs.com/en-uk/interview-buddy",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    images: ["https://www.flashfirejobs.com/images/og-image.png"],
+  },
+};

--- a/app/en-uk/job-application-status-tracker/page.tsx
+++ b/app/en-uk/job-application-status-tracker/page.tsx
@@ -1,0 +1,19 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/job-application-status-tracker/page";
+
+export const metadata: Metadata = {
+  title: "Job Application Status Tracker with AI | Flashfire UK",
+  description:
+    "Track every job application, follow-up, and interview in one AI-powered job application status tracker.",
+  robots: { index: true, follow: true },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-uk/job-application-status-tracker",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/job-application-status-tracker",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/job-application-status-tracker",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/job-application-status-tracker",
+      "x-default": "https://www.flashfirejobs.com/job-application-status-tracker",
+    },
+  },
+};

--- a/app/en-uk/job-search/page.tsx
+++ b/app/en-uk/job-search/page.tsx
@@ -1,0 +1,43 @@
+import { Metadata } from "next";
+import Navbar from "@/src/components/navbar/navbar";
+import Footer from "@/src/components/footer/footer";
+import JobSearch from "@/src/components/pages/jobSearch/JobSearch";
+
+export const metadata: Metadata = {
+  title: "Job Search: Faster Human-Powered Automation",
+  description:
+    "Flashfire applies to relevant jobs on your behalf so you don't have to search manually. Get updates without lifting a finger.",
+  robots: {
+    index: true,
+    follow: true,
+  },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-uk/job-search",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/job-search",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/job-search",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/job-search",
+      "x-default": "https://www.flashfirejobs.com/job-search",
+    },
+  },
+  openGraph: {
+    title: "Job Search: Faster Human-Powered Automation",
+    description:
+      "Flashfire applies to relevant jobs on your behalf so you don't have to search manually.",
+    url: "https://www.flashfirejobs.com/en-uk/job-search",
+    type: "website",
+  },
+};
+
+export default function JobSearchPageUK() {
+  return (
+    <div className="bg-white text-black min-h-screen">
+      <Navbar />
+      <main className="mt-0">
+        <JobSearch />
+      </main>
+      <Footer />
+    </div>
+  );
+}
+

--- a/app/en-uk/offer-and-salary/page.tsx
+++ b/app/en-uk/offer-and-salary/page.tsx
@@ -1,0 +1,49 @@
+import { Metadata } from "next";
+import OfferAndSalary from "@/src/components/offerAndSalary/offerAndSalary";
+import Footer from "@/src/components/footer/footer";
+import Navbar from "@/src/components/navbar/navbar";
+
+export const metadata: Metadata = {
+    title: "Job Offer & Salary Negotiation | Flashfire",
+    description: "Offer & Salary - Flashfire",
+    robots: {
+        index: true,
+        follow: true,
+    },
+    alternates: {
+        canonical: "https://www.flashfirejobs.com/en-uk/offer-and-salary",
+        languages: {
+            "en-US": "https://www.flashfirejobs.com/offer-and-salary-negotiation-advisor",
+            "en-CA": "https://www.flashfirejobs.com/en-ca/offer-and-salary",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/offer-and-salary",
+            "x-default": "https://www.flashfirejobs.com/offer-and-salary-negotiation-advisor",
+        },
+    },
+    openGraph: {
+        title: "Job Offer & Salary Negotiation | Flashfire",
+        description: "Offer & Salary - Flashfire",
+        url: "https://www.flashfirejobs.com/offer-and-salary",
+        siteName: "Flashfire",
+        images: [
+            { url: "https://www.flashfirejobs.com/og-image.png" },
+        ],
+    },
+    twitter: {
+        card: "summary_large_image",
+        title: "Job Offer & Salary Negotiation | Flashfire",
+        description: "Offer & Salary - Flashfire",
+        images: [
+            { url: "https://www.flashfirejobs.com/og-image.png" },
+        ],
+    },
+}
+
+export default function OfferAndSalaryPage() {
+    return (
+        <>
+            <Navbar/>
+            <OfferAndSalary/>
+            <Footer/>
+        </>
+    )
+}

--- a/app/en-uk/page.tsx
+++ b/app/en-uk/page.tsx
@@ -1,0 +1,45 @@
+import { Metadata } from "next";
+import UKHome from "@/src/components/countries/uk/Home";
+
+export const metadata: Metadata = {
+  title: "Flashfire: AI Job Search Automation UK",
+  description:
+    "We apply to 1000+ jobs on your behalf with tailored resumes for every role. Save 150+ hours, skip the grunt work, and stay in control with real-time updates. Your job hunt—automated.",
+  robots: {
+    index: true,
+    follow: true,
+  },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-uk",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/",
+      "en-CA": "https://www.flashfirejobs.com/en-ca",
+      "en-GB": "https://www.flashfirejobs.com/en-uk",
+      "x-default": "https://www.flashfirejobs.com/",
+    },
+  },
+  openGraph: {
+    title: "Flashfire: AI Job Search Automation UK",
+    description:
+      "We apply to 1000+ jobs on your behalf with tailored resumes for every role. Save 150+ hours, skip the grunt work, and stay in control with real-time updates.",
+    url: "https://www.flashfirejobs.com/en-uk",
+    type: "website",
+    images: [
+      {
+        url: "https://www.flashfirejobs.com/images/og-image.png",
+        width: 1200,
+        height: 630,
+        alt: "FLASHFIRE Logo",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    images: ["https://www.flashfirejobs.com/images/og-image.png"],
+  },
+};
+
+export default function HomeUK() {
+  return <UKHome />;
+}
+

--- a/app/en-uk/payment-policy/page.tsx
+++ b/app/en-uk/payment-policy/page.tsx
@@ -1,0 +1,35 @@
+import { Metadata } from "next";
+import PaymentPolicy from "@/src/components/legal/PaymentPolicy";
+import Footer from "@/src/components/footer/footer";
+import Navbar from "@/src/components/navbar/navbar";
+
+export const metadata: Metadata = {
+  title: "Payment Policy - Payment Terms & Methods | Flashfire",
+  description:
+    "Learn about Flashfire's payment policy, accepted payment methods, billing cycles, and refund procedures.",
+  robots: {
+    index: true,
+    follow: true,
+  },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-uk/payment-policy",
+  },
+  openGraph: {
+    title: "Payment Policy - Payment Terms & Methods",
+    description:
+      "Learn about Flashfire's payment policy and accepted payment methods.",
+    url: "https://www.flashfirejobs.com/en-uk/payment-policy",
+    type: "website",
+  },
+};
+
+export default function PaymentPolicyPageUK() {
+  return (
+    <>
+      <Navbar />
+      <PaymentPolicy />
+      <Footer />
+    </>
+  );
+}
+

--- a/app/en-uk/pricing/page.tsx
+++ b/app/en-uk/pricing/page.tsx
@@ -1,0 +1,104 @@
+import { Metadata } from "next";
+import Navbar from "@/src/components/navbar/navbar";
+import Footer from "@/src/components/footer/footer";
+import HomePagePricingPlans from "@/src/components/homePagePricingPlans/homePagePricingPlans";
+import HomePageOfferLetters from "@/src/components/homePageOfferLetters/homePageOfferLetters";
+import HomePageHappyUsers from "@/src/components/homePageHappyUsers/homePageHappyUsers";
+import HomePageFoundersNote from "@/src/components/homePageFoundersNote/homePageFoundersNote";
+import HomePageFAQ from "@/src/components/homePageFAQ/homePageFAQ";
+
+export const metadata: Metadata = {
+  title: "Flashfire UK Pricing: Affordable Job Automation Plans",
+  description:
+    "Choose the perfect Flashfire plan for your job search. Transparent pricing with flexible options to automate your job applications and save time.",
+  robots: {
+    index: true,
+    follow: true,
+  },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-uk/pricing",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/pricing",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/pricing",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/pricing",
+      "x-default": "https://www.flashfirejobs.com/pricing",
+    },
+  },
+  openGraph: {
+    title: "Flashfire UK Pricing: Affordable Job Automation Plans",
+    description:
+      "Choose the perfect Flashfire plan for your job search automation.",
+    url: "https://www.flashfirejobs.com/en-uk/pricing",
+    type: "website",
+  },
+};
+
+export default function PricingPageUK() {
+  const softwareApplicationSchema = {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "Flashfire",
+    "url": "https://www.flashfirejobs.com/en-uk/pricing",
+    "applicationCategory": "BusinessApplication",
+    "operatingSystem": "Web",
+    "description": "AI-powered job search automation platform that finds jobs, optimizes resumes, and applies to roles on your behalf — for UK job seekers.",
+    "offers": [
+      {
+        "@type": "Offer",
+        "name": "PRIME",
+        "price": "79",
+        "priceCurrency": "GBP",
+        "url": "https://www.flashfirejobs.com/en-uk/pricing",
+        "availability": "https://schema.org/InStock",
+        "category": "OneTime"
+      },
+      {
+        "@type": "Offer",
+        "name": "IGNITE",
+        "price": "149",
+        "priceCurrency": "GBP",
+        "url": "https://www.flashfirejobs.com/en-uk/pricing",
+        "availability": "https://schema.org/InStock",
+        "category": "OneTime"
+      },
+      {
+        "@type": "Offer",
+        "name": "PROFESSIONAL",
+        "price": "299",
+        "priceCurrency": "GBP",
+        "url": "https://www.flashfirejobs.com/en-uk/pricing",
+        "availability": "https://schema.org/InStock",
+        "category": "OneTime"
+      },
+      {
+        "@type": "Offer",
+        "name": "EXECUTIVE",
+        "price": "499",
+        "priceCurrency": "GBP",
+        "url": "https://www.flashfirejobs.com/en-uk/pricing",
+        "availability": "https://schema.org/InStock",
+        "category": "OneTime"
+      }
+    ]
+  };
+
+  return (
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(softwareApplicationSchema) }} />
+      <Navbar />
+      <HomePagePricingPlans />
+      <HomePageOfferLetters
+        heading="60+ Offer letters received"
+        enableLoopControls
+        buttonOnlyScroll
+      />
+      <div className="mt-[55px] md:mt-[70px]">
+        <HomePageHappyUsers variant="pricing" />
+      </div>
+      <HomePageHappyUsers variant="pricingVideos" />
+      <HomePageFoundersNote variant="pricing" />
+      <HomePageFAQ />
+      <Footer />
+    </>
+  );
+}

--- a/app/en-uk/privacy-policy/page.tsx
+++ b/app/en-uk/privacy-policy/page.tsx
@@ -1,0 +1,35 @@
+import { Metadata } from "next";
+import PrivacyPolicy from "@/src/components/legal/PrivacyPolicy";
+import Footer from "@/src/components/footer/footer";
+import Navbar from "@/src/components/navbar/navbar";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy - How Flashfire Protects Your Data",
+  description:
+    "Read Flashfire's privacy policy to learn how we collect, use, and protect your personal data throughout the job search automation process.",
+  robots: {
+    index: true,
+    follow: true,
+  },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-uk/privacy-policy",
+  },
+  openGraph: {
+    title: "Privacy Policy - How Flashfire Protects Your Data",
+    description:
+      "Read Flashfire's privacy policy to learn how we collect, use, and protect your personal data.",
+    url: "https://www.flashfirejobs.com/en-uk/privacy-policy",
+    type: "website",
+  },
+};
+
+export default function PrivacyPolicyPageUK() {
+  return (
+    <>
+      <Navbar />
+      <PrivacyPolicy />
+      <Footer />
+    </>
+  );
+}
+

--- a/app/en-uk/recent-job-openings/page.tsx
+++ b/app/en-uk/recent-job-openings/page.tsx
@@ -1,0 +1,48 @@
+import{Metadata} from "next";
+import RecentJobOpenings from "@/src/components/recentJobOpenings/recentJobOpenings";
+import Footer from "@/src/components/footer/footer";
+import Navbar from "@/src/components/navbar/navbar";
+export const metadata: Metadata = {
+    title: "Recent UK Job Openings | Flashfire",
+    description: "Recent Job Openings - Flashfire",
+    robots: {
+        index: true,
+        follow: true,
+    },
+    alternates: {
+        canonical: "https://www.flashfirejobs.com/en-uk/recent-job-openings",
+        languages: {
+            "en-US": "https://www.flashfirejobs.com/recent-job-openings",
+            "en-CA": "https://www.flashfirejobs.com/en-ca/recent-job-openings",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/recent-job-openings",
+            "x-default": "https://www.flashfirejobs.com/recent-job-openings",
+        },
+    },
+    openGraph: {
+        title: "Recent UK Job Openings | Flashfire",
+        description: "Recent Job Openings - Flashfire",
+        url: "https://www.flashfirejobs.com/recent-job-openings",
+        siteName: "Flashfire",
+        images: [
+            { url: "https://www.flashfirejobs.com/images/og-image.png" },
+        ],
+    },
+    twitter: {
+        card: "summary_large_image",
+        title: "Recent UK Job Openings | Flashfire",
+        description: "Recent Job Openings - Flashfire",
+        images: [
+            { url: "https://www.flashfirejobs.com/images/og-image.png" },
+        ],
+    },
+};
+
+export default function RecentJobOpeningsPage() {
+    return (
+        <>
+            <Navbar/>
+            <RecentJobOpenings/>
+            <Footer/>
+        </>
+    )
+}

--- a/app/en-uk/refund-policy/page.tsx
+++ b/app/en-uk/refund-policy/page.tsx
@@ -1,0 +1,35 @@
+import { Metadata } from "next";
+import RefundPolicy from "@/src/components/legal/RefundPolicy";
+import Footer from "@/src/components/footer/footer";
+import Navbar from "@/src/components/navbar/navbar";
+
+export const metadata: Metadata = {
+  title: "Refund Policy - Flashfire Guarantee & Eligibility",
+  description:
+    "Understand Flashfire's refund policy, eligibility criteria, and process for requesting a refund on our job search automation services.",
+  robots: {
+    index: true,
+    follow: true,
+  },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-uk/refund-policy",
+  },
+  openGraph: {
+    title: "Refund Policy - Flashfire Guarantee & Eligibility",
+    description:
+      "Understand Flashfire's refund policy, eligibility criteria, and process for requesting a refund.",
+    url: "https://www.flashfirejobs.com/en-uk/refund-policy",
+    type: "website",
+  },
+};
+
+export default function RefundPolicyPageUK() {
+  return (
+    <>
+      <Navbar />
+      <RefundPolicy />
+      <Footer />
+    </>
+  );
+}
+

--- a/app/en-uk/resume-bullet-point-generator/page.tsx
+++ b/app/en-uk/resume-bullet-point-generator/page.tsx
@@ -1,0 +1,17 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/resume-bullet-point-generator/page";
+
+export const metadata: Metadata = {
+  title: "Resume Bullet Point Generator | Flashfire UK",
+  description: "Turn vague job duties into sharp, ATS-friendly bullet points. Free AI resume bullet point generator.",
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-uk/resume-bullet-point-generator",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/resume-bullet-point-generator",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/resume-bullet-point-generator",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/resume-bullet-point-generator",
+      "x-default": "https://www.flashfirejobs.com/resume-bullet-point-generator",
+    },
+  },
+};

--- a/app/en-uk/resume-headline-generator/page.tsx
+++ b/app/en-uk/resume-headline-generator/page.tsx
@@ -1,0 +1,17 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/resume-headline-generator/page";
+
+export const metadata: Metadata = {
+  title: "Resume Headline Generator | Flashfire UK",
+  description: "Generate 5 AI-powered, recruiter-tested resume headlines instantly. Free resume headline generator.",
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-uk/resume-headline-generator",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/resume-headline-generator",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/resume-headline-generator",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/resume-headline-generator",
+      "x-default": "https://www.flashfirejobs.com/resume-headline-generator",
+    },
+  },
+};

--- a/app/en-uk/resume-parser/page.tsx
+++ b/app/en-uk/resume-parser/page.tsx
@@ -1,0 +1,17 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/resume-parser/page";
+
+export const metadata: Metadata = {
+  title: "Resume Parser | Flashfire UK",
+  description: "Extract structured data from your resume instantly. Free online resume parser.",
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-uk/resume-parser",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/resume-parser",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/resume-parser",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/resume-parser",
+      "x-default": "https://www.flashfirejobs.com/resume-parser",
+    },
+  },
+};

--- a/app/en-uk/salary-calculator/page.tsx
+++ b/app/en-uk/salary-calculator/page.tsx
@@ -1,0 +1,25 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/salary-calculator/page";
+
+export const metadata: Metadata = {
+  title: "Salary Calculator – Estimate Take-Home Pay | Flashfire UK",
+  description: "Calculate your take-home pay from annual salary. Includes bonus, pre-tax deductions, federal and provincial tax estimates.",
+  robots: { index: true, follow: true },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-uk/salary-calculator",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/salary-calculator",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/salary-calculator",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/salary-calculator",
+      "x-default": "https://www.flashfirejobs.com/salary-calculator",
+    },
+  },
+  openGraph: {
+    title: "Salary Calculator – Estimate Take-Home Pay | Flashfire UK",
+    description: "Calculate your take-home pay from annual salary. Includes bonus, pre-tax deductions, federal and provincial tax estimates.",
+    url: "https://www.flashfirejobs.com/en-uk/salary-calculator",
+    type: "website",
+  },
+  twitter: { card: "summary_large_image", images: ["https://www.flashfirejobs.com/images/og-image.png"] },
+};

--- a/app/en-uk/salary-comparison/page.tsx
+++ b/app/en-uk/salary-comparison/page.tsx
@@ -1,0 +1,25 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/salary-comparison/page";
+
+export const metadata: Metadata = {
+  title: "Salary Comparison – Compare Two Job Offers | Flashfire UK",
+  description: "Compare two job offers side by side including salary, bonus, benefits, and commute costs to find the better total value.",
+  robots: { index: true, follow: true },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-uk/salary-comparison",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/salary-comparison",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/salary-comparison",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/salary-comparison",
+      "x-default": "https://www.flashfirejobs.com/salary-comparison",
+    },
+  },
+  openGraph: {
+    title: "Salary Comparison – Compare Two Job Offers | Flashfire UK",
+    description: "Compare two job offers side by side including salary, bonus, benefits, and commute costs to find the better total value.",
+    url: "https://www.flashfirejobs.com/en-uk/salary-comparison",
+    type: "website",
+  },
+  twitter: { card: "summary_large_image", images: ["https://www.flashfirejobs.com/images/og-image.png"] },
+};

--- a/app/en-uk/salary-estimator/page.tsx
+++ b/app/en-uk/salary-estimator/page.tsx
@@ -1,0 +1,25 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/salary-estimator/page";
+
+export const metadata: Metadata = {
+  title: "Salary Estimator – Realistic Salary Range by Role | Flashfire UK",
+  description: "Estimate a salary range based on role, experience, location, and skill premium. Great for job offer planning and negotiation.",
+  robots: { index: true, follow: true },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-uk/salary-estimator",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/salary-estimator",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/salary-estimator",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/salary-estimator",
+      "x-default": "https://www.flashfirejobs.com/salary-estimator",
+    },
+  },
+  openGraph: {
+    title: "Salary Estimator – Realistic Salary Range by Role | Flashfire UK",
+    description: "Estimate a salary range based on role, experience, location, and skill premium. Great for job offer planning and negotiation.",
+    url: "https://www.flashfirejobs.com/en-uk/salary-estimator",
+    type: "website",
+  },
+  twitter: { card: "summary_large_image", images: ["https://www.flashfirejobs.com/images/og-image.png"] },
+};

--- a/app/en-uk/see-flashfire-in-action/page.tsx
+++ b/app/en-uk/see-flashfire-in-action/page.tsx
@@ -1,0 +1,39 @@
+import { Metadata } from "next";
+import HomePage from "@/src/components/pages/home/Home";
+import ScrollToSection from "@/src/utils/ui/scrollToSection";
+
+export const metadata: Metadata = {
+  title: "Watch Flashfire Live Demo & Product Tour",
+  description:
+    "Watch Flashfire in action. See how our AI-powered job search automation works with a live demo of our platform features.",
+  robots: {
+    index: true,
+    follow: true,
+  },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-uk/see-flashfire-in-action",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/see-flashfire-in-action",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/see-flashfire-in-action",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/see-flashfire-in-action",
+      "x-default": "https://www.flashfirejobs.com/see-flashfire-in-action",
+    },
+  },
+  openGraph: {
+    title: "Watch Flashfire Live Demo & Product Tour",
+    description:
+      "Watch Flashfire in action with a live demo of our platform.",
+    url: "https://www.flashfirejobs.com/en-uk/see-flashfire-in-action",
+    type: "website",
+  },
+};
+
+export default function SeeFlashfireInActionPageUK() {
+  return (
+    <>
+      <HomePage />
+      <ScrollToSection targetId="demo" />
+    </>
+  );
+}
+

--- a/app/en-uk/take-home-pay-calculator/page.tsx
+++ b/app/en-uk/take-home-pay-calculator/page.tsx
@@ -1,0 +1,25 @@
+import { Metadata } from "next";
+
+export { default } from "@/app/take-home-pay-calculator/page";
+
+export const metadata: Metadata = {
+  title: "Take Home Pay Calculator – Net Paycheck Estimator | Flashfire UK",
+  description: "See your actual take-home pay after taxes and deductions. Enter gross pay, frequency, and provincial tax to get your net paycheck.",
+  robots: { index: true, follow: true },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-uk/take-home-pay-calculator",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/take-home-pay-calculator",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/take-home-pay-calculator",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/take-home-pay-calculator",
+      "x-default": "https://www.flashfirejobs.com/take-home-pay-calculator",
+    },
+  },
+  openGraph: {
+    title: "Take Home Pay Calculator – Net Paycheck Estimator | Flashfire UK",
+    description: "See your actual take-home pay after taxes and deductions. Enter gross pay, frequency, and provincial tax to get your net paycheck.",
+    url: "https://www.flashfirejobs.com/en-uk/take-home-pay-calculator",
+    type: "website",
+  },
+  twitter: { card: "summary_large_image", images: ["https://www.flashfirejobs.com/images/og-image.png"] },
+};

--- a/app/en-uk/talk-to-an-expert/page.tsx
+++ b/app/en-uk/talk-to-an-expert/page.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useEffect, Suspense } from "react";
+import { useSearchParams } from "next/navigation";
+import HomePage from "@/src/components/pages/home/Home";
+import { WHATSAPP_SUPPORT_URL } from "@/src/utils/whatsapp";
+import { GTagUTM } from "@/src/utils/GTagUTM";
+import { trackButtonClick, trackExternalLink } from "@/src/utils/PostHogTracking";
+
+function TalkToAnExpertContentUK() {
+  const searchParams = useSearchParams();
+  
+  useEffect(() => {
+    // Get UTM parameters from URL params or localStorage
+    const utmSource = searchParams.get("utm_source") || 
+      (typeof window !== "undefined" ? localStorage.getItem("utm_source") : null) || 
+      "WEBSITE";
+    const utmMedium = searchParams.get("utm_medium") || 
+      (typeof window !== "undefined" ? localStorage.getItem("utm_medium") : null) || 
+      "Navigation_Navbar_Button";
+    const utmCampaign = searchParams.get("utm_campaign") || 
+      (typeof window !== "undefined" ? localStorage.getItem("utm_campaign") : null) || 
+      "Website";
+
+    // Track with both GTag and PostHog
+    GTagUTM({
+      eventName: "whatsapp_support_click",
+      label: "Navbar_Talk_To_Expert_Button_CA",
+      utmParams: {
+        utm_source: utmSource,
+        utm_medium: utmMedium,
+        utm_campaign: utmCampaign,
+      },
+    });
+
+    // PostHog tracking
+    trackButtonClick("Talk to an Expert", "navigation", "cta", {
+      button_location: "navbar",
+      navigation_type: "primary_cta",
+      page: "talk-to-an-expert",
+      locale: "en-ca",
+    });
+    trackExternalLink(WHATSAPP_SUPPORT_URL, "Talk to an Expert", "navigation", {
+      link_type: "whatsapp_support",
+      contact_method: "whatsapp",
+      source: "navbar_button",
+      locale: "en-ca",
+    });
+
+    // Open WhatsApp in a new tab
+    window.open(WHATSAPP_SUPPORT_URL, "_blank");
+  }, [searchParams]);
+
+  return <HomePage />;
+}
+
+export default function TalkToAnExpertPageUK() {
+  return (
+    <Suspense fallback={<HomePage />}>
+      <TalkToAnExpertContentUK />
+    </Suspense>
+  );
+}
+

--- a/app/en-uk/talk-to-an-expert/page.tsx
+++ b/app/en-uk/talk-to-an-expert/page.tsx
@@ -38,13 +38,13 @@ function TalkToAnExpertContentUK() {
       button_location: "navbar",
       navigation_type: "primary_cta",
       page: "talk-to-an-expert",
-      locale: "en-ca",
+      locale: "en-uk",
     });
     trackExternalLink(WHATSAPP_SUPPORT_URL, "Talk to an Expert", "navigation", {
       link_type: "whatsapp_support",
       contact_method: "whatsapp",
       source: "navbar_button",
-      locale: "en-ca",
+      locale: "en-uk",
     });
 
     // Open WhatsApp in a new tab

--- a/app/en-uk/terms-of-service/page.tsx
+++ b/app/en-uk/terms-of-service/page.tsx
@@ -1,0 +1,35 @@
+import { Metadata } from "next";
+import TermsOfService from "@/src/components/legal/TermsOfService";
+import Footer from "@/src/components/footer/footer";
+import Navbar from "@/src/components/navbar/navbar";
+
+export const metadata: Metadata = {
+  title: "Terms of Service - Flashfire User Agreement",
+  description:
+    "Read Flashfire's terms of service to understand the terms and conditions for using our job search automation platform.",
+  robots: {
+    index: true,
+    follow: true,
+  },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-uk/terms-of-service",
+  },
+  openGraph: {
+    title: "Terms of Service - Flashfire User Agreement",
+    description:
+      "Read Flashfire's terms of service and user agreement.",
+    url: "https://www.flashfirejobs.com/en-uk/terms-of-service",
+    type: "website",
+  },
+};
+
+export default function TermsOfServicePageUK() {
+  return (
+    <>
+      <Navbar />
+      <TermsOfService />
+      <Footer />
+    </>
+  );
+}
+

--- a/app/en-uk/testimonials/page.tsx
+++ b/app/en-uk/testimonials/page.tsx
@@ -1,0 +1,53 @@
+import { Metadata } from "next";
+import Navbar from "@/src/components/navbar/navbar";
+import Footer from "@/src/components/footer/footer";
+import HappyUsersGalleryPage from "@/src/components/homePageHappyUsers/HappyUsersGalleryPage";
+
+export const metadata: Metadata = {
+  title: "Flashfire Reviews: Success Stories & Testimonials",
+  description:
+    "See real success stories from job seekers who landed their dream jobs with Flashfire. Read testimonials from professionals who automated their job search and saved 150+ hours.",
+  robots: {
+    index: true,
+    follow: true,
+  },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-uk/testimonials",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/testimonials",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/testimonials",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/testimonials",
+      "x-default": "https://www.flashfirejobs.com/testimonials",
+    },
+  },
+  openGraph: {
+    title: "Flashfire Reviews: Success Stories & Testimonials",
+    description:
+      "See real success stories from job seekers who landed their dream jobs with Flashfire.",
+    url: "https://www.flashfirejobs.com/en-uk/testimonials",
+    type: "website",
+    images: [
+      {
+        url: "https://www.flashfirejobs.com/images/og-image.png",
+        width: 1200,
+        height: 630,
+        alt: "FLASHFIRE Logo",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    images: ["https://www.flashfirejobs.com/images/og-image.png"],
+  },
+};
+
+export default function TestimonialsPageUK() {
+  return (
+    <>
+      <Navbar />
+      <HappyUsersGalleryPage heading="Real Stories from UK Job Seekers" />
+      <Footer />
+    </>
+  );
+}
+

--- a/app/faq/page.tsx
+++ b/app/faq/page.tsx
@@ -16,6 +16,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/faq",
       "en-CA": "https://www.flashfirejobs.com/en-ca/faq",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/faq",
       "x-default": "https://www.flashfirejobs.com/faq",
     },
   },

--- a/app/features/ai-cover-letter-generator/page.tsx
+++ b/app/features/ai-cover-letter-generator/page.tsx
@@ -20,6 +20,7 @@ import faqStyles from "@/src/components/homePageFAQ/homePageFAQ.module.css";
 import { GTagUTM } from "@/src/utils/GTagUTM";
 import { trackButtonClick, trackSignupIntent } from "@/src/utils/PostHogTracking";
 import { useGeoBypass } from "@/src/utils/useGeoBypass";
+import { localizeHref, stripLocalePrefix } from "@/src/utils/locale";
 
 export default function CoverLetterPage() {
   const router = useRouter();
@@ -151,13 +152,10 @@ export default function CoverLetterPage() {
         pathname || (typeof window !== "undefined" ? window.location.pathname : "");
       const normalizedPath = currentPath.split("?")[0];
       const isAlreadyOnGetMeInterview =
-        normalizedPath === "/get-me-interview" ||
-        normalizedPath === "/en-ca/get-me-interview";
+        stripLocalePrefix(normalizedPath) === "/get-me-interview";
       const isOnCoverLetterPage =
-        normalizedPath === "/features/cover-letter" ||
-        normalizedPath === "/en-ca/features/cover-letter" ||
-        normalizedPath === "/features/ai-cover-letter-generator" ||
-        normalizedPath === "/en-ca/features/ai-cover-letter-generator";
+        stripLocalePrefix(normalizedPath) === "/features/cover-letter" ||
+        stripLocalePrefix(normalizedPath) === "/features/ai-cover-letter-generator";
 
       if (isAlreadyOnGetMeInterview) {
         const currentScrollY = typeof window !== "undefined" ? window.scrollY : 0;
@@ -178,7 +176,7 @@ export default function CoverLetterPage() {
           window.history.pushState(
             {},
             "",
-            normalizedPath.startsWith("/en-ca") ? "/en-ca/get-me-interview" : "/get-me-interview"
+            localizeHref("/get-me-interview", normalizedPath)
           );
         }
         requestAnimationFrame(() => window.scrollTo({ top: currentScrollY, behavior: "instant" }));

--- a/app/features/ai-job-targeting/page.tsx
+++ b/app/features/ai-job-targeting/page.tsx
@@ -21,6 +21,7 @@ import Footer from "@/src/components/footer/footer";
 import { GTagUTM } from "@/src/utils/GTagUTM";
 import { trackButtonClick, trackSignupIntent } from "@/src/utils/PostHogTracking";
 import { useGeoBypass } from "@/src/utils/useGeoBypass";
+import { localizeHref, stripLocalePrefix } from "@/src/utils/locale";
 
 export default function PrecisionTargetingPage() {
   const router = useRouter();
@@ -72,13 +73,10 @@ export default function PrecisionTargetingPage() {
         pathname || (typeof window !== "undefined" ? window.location.pathname : "");
       const normalizedPath = currentPath.split("?")[0];
       const isAlreadyOnGetMeInterview =
-        normalizedPath === "/get-me-interview" ||
-        normalizedPath === "/en-ca/get-me-interview";
+        stripLocalePrefix(normalizedPath) === "/get-me-interview";
       const isOnPrecisionTargetingPage =
-        normalizedPath === "/features/precision-targeting" ||
-        normalizedPath === "/en-ca/features/precision-targeting" ||
-        normalizedPath === "/features/ai-job-targeting" ||
-        normalizedPath === "/en-ca/features/ai-job-targeting";
+        stripLocalePrefix(normalizedPath) === "/features/precision-targeting" ||
+        stripLocalePrefix(normalizedPath) === "/features/ai-job-targeting";
 
       if (isAlreadyOnGetMeInterview) {
         const currentScrollY = typeof window !== "undefined" ? window.scrollY : 0;
@@ -99,7 +97,7 @@ export default function PrecisionTargetingPage() {
           window.history.pushState(
             {},
             "",
-            normalizedPath.startsWith("/en-ca") ? "/en-ca/get-me-interview" : "/get-me-interview"
+            localizeHref("/get-me-interview", normalizedPath)
           );
         }
         requestAnimationFrame(() => window.scrollTo({ top: currentScrollY, behavior: "instant" }));

--- a/app/features/ats-resume-optimizer/page.tsx
+++ b/app/features/ats-resume-optimizer/page.tsx
@@ -28,6 +28,7 @@ import styles from "@/src/components/homePageFAQ/homePageFAQ.module.css"
 import { trackButtonClick, trackSignupIntent } from "@/src/utils/PostHogTracking"
 import { GTagUTM } from "@/src/utils/GTagUTM"
 import { useGeoBypass } from "@/src/utils/useGeoBypass"
+import { localizeHref, stripLocalePrefix } from "@/src/utils/locale";
 
 const ORANGE = "#ff4c00"
 
@@ -376,16 +377,12 @@ export default function Page() {
       const currentPath = pathname || (typeof window !== "undefined" ? window.location.pathname : "")
       const normalizedPath = currentPath.split("?")[0]
       const isAlreadyOnGetMeInterview =
-        normalizedPath === "/get-me-interview" || normalizedPath === "/en-ca/get-me-interview"
+        stripLocalePrefix(normalizedPath) === "/get-me-interview"
       const isOnATSPage =
-        normalizedPath === "/ats-optimized-resume-checker" ||
-        normalizedPath === "/en-ca/ats-optimized-resume-checker" ||
-        normalizedPath === "/features/resume-optimizer" ||
-        normalizedPath === "/en-ca/features/resume-optimizer" ||
-        normalizedPath === "/features/ats-optimizer" ||
-        normalizedPath === "/en-ca/features/ats-optimizer" ||
-        normalizedPath === "/features/ats-resume-optimizer" ||
-        normalizedPath === "/en-ca/features/ats-resume-optimizer"
+        stripLocalePrefix(normalizedPath) === "/ats-optimized-resume-checker" ||
+        stripLocalePrefix(normalizedPath) === "/features/resume-optimizer" ||
+        stripLocalePrefix(normalizedPath) === "/features/ats-optimizer" ||
+        stripLocalePrefix(normalizedPath) === "/features/ats-resume-optimizer"
 
       if (isAlreadyOnGetMeInterview) {
         const currentScrollY = typeof window !== "undefined" ? window.scrollY : 0
@@ -415,7 +412,7 @@ export default function Page() {
         const currentScrollY = typeof window !== "undefined" ? window.scrollY : 0
 
         if (typeof window !== "undefined") {
-          const targetPath = normalizedPath.startsWith("/en-ca") ? "/en-ca/get-me-interview" : "/get-me-interview"
+          const targetPath = localizeHref("/get-me-interview", normalizedPath)
           window.history.pushState({}, "", targetPath)
         }
 

--- a/app/features/automated-job-applications/page.tsx
+++ b/app/features/automated-job-applications/page.tsx
@@ -20,6 +20,7 @@ import {
   FaTimes,
 } from "react-icons/fa";
 import faqStyles from "@/src/components/homePageFAQ/homePageFAQ.module.css";
+import { localizeHref, stripLocalePrefix } from "@/src/utils/locale";
 
 const stats = [
   { value: "1,200+", label: "Applications Automated" },
@@ -331,15 +332,11 @@ export default function JobApplicationAutomationPage() {
         pathname || (typeof window !== "undefined" ? window.location.pathname : "");
       const normalizedPath = currentPath.split("?")[0];
       const isAlreadyOnGetMeInterview =
-        normalizedPath === "/get-me-interview" ||
-        normalizedPath === "/en-ca/get-me-interview";
+        stripLocalePrefix(normalizedPath) === "/get-me-interview";
       const isOnJobAutomationPage =
-        normalizedPath === "/job-application-automation" ||
-        normalizedPath === "/en-ca/job-application-automation" ||
-        normalizedPath === "/features/job-automation" ||
-        normalizedPath === "/en-ca/features/job-automation" ||
-        normalizedPath === "/features/automated-job-applications" ||
-        normalizedPath === "/en-ca/features/automated-job-applications";
+        stripLocalePrefix(normalizedPath) === "/job-application-automation" ||
+        stripLocalePrefix(normalizedPath) === "/features/job-automation" ||
+        stripLocalePrefix(normalizedPath) === "/features/automated-job-applications";
 
       if (isAlreadyOnGetMeInterview) {
         const currentScrollY = typeof window !== "undefined" ? window.scrollY : 0;
@@ -360,9 +357,7 @@ export default function JobApplicationAutomationPage() {
           window.history.pushState(
             {},
             "",
-            normalizedPath.startsWith("/en-ca")
-              ? "/en-ca/get-me-interview"
-              : "/get-me-interview"
+            localizeHref("/get-me-interview", normalizedPath)
           );
         }
         requestAnimationFrame(() =>

--- a/app/features/cover-letter/layout.tsx
+++ b/app/features/cover-letter/layout.tsx
@@ -6,6 +6,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/features/cover-letter",
       "en-CA": "https://www.flashfirejobs.com/en-ca/features/cover-letter",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/features/cover-letter",
       "x-default": "https://www.flashfirejobs.com/features/cover-letter",
     },
   },

--- a/app/features/cover-letter/page.tsx
+++ b/app/features/cover-letter/page.tsx
@@ -8,6 +8,7 @@ import { FileText, CheckCircle, Zap, Sparkles, Target, TrendingUp } from "lucide
 import { trackButtonClick, trackSignupIntent } from "@/src/utils/PostHogTracking";
 import { GTagUTM } from "@/src/utils/GTagUTM";
 import { useGeoBypass } from "@/src/utils/useGeoBypass";
+import { localizeHref, stripLocalePrefix } from "@/src/utils/locale";
 
 export default function CoverLetterPage() {
   const router = useRouter();
@@ -59,12 +60,9 @@ export default function CoverLetterPage() {
       // Check current path first
       const currentPath = pathname || (typeof window !== 'undefined' ? window.location.pathname : '');
       const normalizedPath = currentPath.split('?')[0];
-      const isAlreadyOnGetMeInterview = normalizedPath === '/get-me-interview' ||
-        normalizedPath === '/en-ca/get-me-interview';
-      const isOnCoverLetterPage = normalizedPath === '/features/cover-letter' ||
-        normalizedPath === '/en-ca/features/cover-letter' ||
-        normalizedPath === '/features/ai-cover-letter-generator' ||
-        normalizedPath === '/en-ca/features/ai-cover-letter-generator';
+      const isAlreadyOnGetMeInterview = stripLocalePrefix(normalizedPath) === '/get-me-interview';
+      const isOnCoverLetterPage = stripLocalePrefix(normalizedPath) === '/features/cover-letter' ||
+        stripLocalePrefix(normalizedPath) === '/features/ai-cover-letter-generator';
 
       // If already on the route, save scroll position and prevent navigation
       if (isAlreadyOnGetMeInterview) {
@@ -98,7 +96,7 @@ export default function CoverLetterPage() {
 
         // Update URL for tracking without navigation
         if (typeof window !== 'undefined') {
-          const targetPath = normalizedPath.startsWith('/en-ca') ? '/en-ca/get-me-interview' : '/get-me-interview';
+          const targetPath = localizeHref('/get-me-interview', normalizedPath);
           window.history.pushState({}, '', targetPath);
         }
 

--- a/app/features/dashboard-analytics/layout.tsx
+++ b/app/features/dashboard-analytics/layout.tsx
@@ -8,6 +8,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/features/dashboard-analytics",
       "en-CA": "https://www.flashfirejobs.com/en-ca/features/dashboard-analytics",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/features/dashboard-analytics",
       "x-default": "https://www.flashfirejobs.com/features/dashboard-analytics",
     },
   },

--- a/app/features/dashboard-analytics/page.tsx
+++ b/app/features/dashboard-analytics/page.tsx
@@ -13,6 +13,7 @@ import faqStyles from "@/src/components/homePageFAQ/homePageFAQ.module.css";
 import { GTagUTM } from "@/src/utils/GTagUTM";
 import { trackButtonClick, trackSignupIntent } from "@/src/utils/PostHogTracking";
 import { useGeoBypass } from "@/src/utils/useGeoBypass";
+import { localizeHref, stripLocalePrefix } from "@/src/utils/locale";
 
 export default function DashboardAnalyticsPage() {
   const router = useRouter();
@@ -182,11 +183,9 @@ export default function DashboardAnalyticsPage() {
         pathname || (typeof window !== "undefined" ? window.location.pathname : "");
       const normalizedPath = currentPath.split("?")[0];
       const isAlreadyOnGetMeInterview =
-        normalizedPath === "/get-me-interview" ||
-        normalizedPath === "/en-ca/get-me-interview";
+        stripLocalePrefix(normalizedPath) === "/get-me-interview";
       const isOnDashboardAnalyticsPage =
-        normalizedPath === "/features/dashboard-analytics" ||
-        normalizedPath === "/en-ca/features/dashboard-analytics";
+        stripLocalePrefix(normalizedPath) === "/features/dashboard-analytics";
 
       if (isAlreadyOnGetMeInterview) {
         const currentScrollY = typeof window !== "undefined" ? window.scrollY : 0;
@@ -207,7 +206,7 @@ export default function DashboardAnalyticsPage() {
           window.history.pushState(
             {},
             "",
-            normalizedPath.startsWith("/en-ca") ? "/en-ca/get-me-interview" : "/get-me-interview"
+            localizeHref("/get-me-interview", normalizedPath)
           );
         }
         requestAnimationFrame(() => window.scrollTo({ top: currentScrollY, behavior: "instant" }));

--- a/app/features/interview-tips/layout.tsx
+++ b/app/features/interview-tips/layout.tsx
@@ -8,6 +8,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/features/interview-tips",
       "en-CA": "https://www.flashfirejobs.com/en-ca/features/interview-tips",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/features/interview-tips",
       "x-default": "https://www.flashfirejobs.com/features/interview-tips",
     },
   },

--- a/app/features/job-application-tracker/page.tsx
+++ b/app/features/job-application-tracker/page.tsx
@@ -19,6 +19,7 @@ import faqStyles from "@/src/components/homePageFAQ/homePageFAQ.module.css";
 import { GTagUTM } from "@/src/utils/GTagUTM";
 import { trackButtonClick, trackSignupIntent } from "@/src/utils/PostHogTracking";
 import { useGeoBypass } from "@/src/utils/useGeoBypass";
+import { localizeHref, stripLocalePrefix } from "@/src/utils/locale";
 
 export default function JobTrackerPage() {
   const router = useRouter();
@@ -271,13 +272,10 @@ export default function JobTrackerPage() {
         pathname || (typeof window !== "undefined" ? window.location.pathname : "");
       const normalizedPath = currentPath.split("?")[0];
       const isAlreadyOnGetMeInterview =
-        normalizedPath === "/get-me-interview" ||
-        normalizedPath === "/en-ca/get-me-interview";
+        stripLocalePrefix(normalizedPath) === "/get-me-interview";
       const isOnJobTrackerPage =
-        normalizedPath === "/features/job-tracker" ||
-        normalizedPath === "/en-ca/features/job-tracker" ||
-        normalizedPath === "/features/job-application-tracker" ||
-        normalizedPath === "/en-ca/features/job-application-tracker";
+        stripLocalePrefix(normalizedPath) === "/features/job-tracker" ||
+        stripLocalePrefix(normalizedPath) === "/features/job-application-tracker";
 
       if (isAlreadyOnGetMeInterview) {
         const currentScrollY = typeof window !== "undefined" ? window.scrollY : 0;
@@ -307,9 +305,7 @@ export default function JobTrackerPage() {
         const currentScrollY = typeof window !== "undefined" ? window.scrollY : 0;
 
         if (typeof window !== "undefined") {
-          const targetPath = normalizedPath.startsWith("/en-ca")
-            ? "/en-ca/get-me-interview"
-            : "/get-me-interview";
+          const targetPath = localizeHref("/get-me-interview", normalizedPath);
           window.history.pushState({}, "", targetPath);
         }
 

--- a/app/features/job-automation/layout.tsx
+++ b/app/features/job-automation/layout.tsx
@@ -6,6 +6,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/features/job-automation",
       "en-CA": "https://www.flashfirejobs.com/en-ca/features/job-automation",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/features/job-automation",
       "x-default": "https://www.flashfirejobs.com/features/job-automation",
     },
   },

--- a/app/features/job-automation/page.tsx
+++ b/app/features/job-automation/page.tsx
@@ -9,6 +9,7 @@ import { GTagUTM } from "@/src/utils/GTagUTM";
 import { useGeoBypass } from "@/src/utils/useGeoBypass";
 import { FaPlus, FaTimes } from "react-icons/fa";
 import faqStyles from "@/src/components/homePageFAQ/homePageFAQ.module.css";
+import { localizeHref, stripLocalePrefix } from "@/src/utils/locale";
 
 export default function JobApplicationAutomationPage() {
   const [isMounted, setIsMounted] = useState(false);
@@ -114,14 +115,10 @@ export default function JobApplicationAutomationPage() {
       // Check current path first
       const currentPath = pathname || (typeof window !== 'undefined' ? window.location.pathname : '');
       const normalizedPath = currentPath.split('?')[0];
-      const isAlreadyOnGetMeInterview = normalizedPath === '/get-me-interview' ||
-        normalizedPath === '/en-ca/get-me-interview';
-      const isOnJobAutomationPage = normalizedPath === '/job-application-automation' ||
-        normalizedPath === '/en-ca/job-application-automation' ||
-        normalizedPath === '/features/job-automation' ||
-        normalizedPath === '/en-ca/features/job-automation' ||
-        normalizedPath === '/features/automated-job-applications' ||
-        normalizedPath === '/en-ca/features/automated-job-applications';
+      const isAlreadyOnGetMeInterview = stripLocalePrefix(normalizedPath) === '/get-me-interview';
+      const isOnJobAutomationPage = stripLocalePrefix(normalizedPath) === '/job-application-automation' ||
+        stripLocalePrefix(normalizedPath) === '/features/job-automation' ||
+        stripLocalePrefix(normalizedPath) === '/features/automated-job-applications';
 
       // If already on the route, save scroll position and prevent navigation
       if (isAlreadyOnGetMeInterview) {
@@ -155,7 +152,7 @@ export default function JobApplicationAutomationPage() {
         
         // Update URL for tracking without navigation
         if (typeof window !== 'undefined') {
-          const targetPath = normalizedPath.startsWith('/en-ca') ? '/en-ca/get-me-interview' : '/get-me-interview';
+          const targetPath = localizeHref('/get-me-interview', normalizedPath);
           window.history.pushState({}, '', targetPath);
         }
         

--- a/app/features/job-tracker/layout.tsx
+++ b/app/features/job-tracker/layout.tsx
@@ -6,6 +6,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/features/job-tracker",
       "en-CA": "https://www.flashfirejobs.com/en-ca/features/job-tracker",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/features/job-tracker",
       "x-default": "https://www.flashfirejobs.com/features/job-tracker",
     },
   },

--- a/app/features/job-tracker/page.tsx
+++ b/app/features/job-tracker/page.tsx
@@ -8,6 +8,7 @@ import { CheckCircle, Target, BarChart, TrendingUp, Clock, Zap } from "lucide-re
 import { trackButtonClick, trackSignupIntent } from "@/src/utils/PostHogTracking";
 import { GTagUTM } from "@/src/utils/GTagUTM";
 import { useGeoBypass } from "@/src/utils/useGeoBypass";
+import { localizeHref, stripLocalePrefix } from "@/src/utils/locale";
 
 export default function JobTrackerPage() {
   const router = useRouter();
@@ -59,12 +60,9 @@ export default function JobTrackerPage() {
       // Check current path first
       const currentPath = pathname || (typeof window !== 'undefined' ? window.location.pathname : '');
       const normalizedPath = currentPath.split('?')[0];
-      const isAlreadyOnGetMeInterview = normalizedPath === '/get-me-interview' ||
-        normalizedPath === '/en-ca/get-me-interview';
-      const isOnJobTrackerPage = normalizedPath === '/features/job-tracker' ||
-        normalizedPath === '/en-ca/features/job-tracker' ||
-        normalizedPath === '/features/job-application-tracker' ||
-        normalizedPath === '/en-ca/features/job-application-tracker';
+      const isAlreadyOnGetMeInterview = stripLocalePrefix(normalizedPath) === '/get-me-interview';
+      const isOnJobTrackerPage = stripLocalePrefix(normalizedPath) === '/features/job-tracker' ||
+        stripLocalePrefix(normalizedPath) === '/features/job-application-tracker';
 
       // If already on the route, save scroll position and prevent navigation
       if (isAlreadyOnGetMeInterview) {
@@ -98,7 +96,7 @@ export default function JobTrackerPage() {
 
         // Update URL for tracking without navigation
         if (typeof window !== 'undefined') {
-          const targetPath = normalizedPath.startsWith('/en-ca') ? '/en-ca/get-me-interview' : '/get-me-interview';
+          const targetPath = localizeHref('/get-me-interview', normalizedPath);
           window.history.pushState({}, '', targetPath);
         }
 

--- a/app/features/linkedin-profile-optimization-tool/page.tsx
+++ b/app/features/linkedin-profile-optimization-tool/page.tsx
@@ -12,6 +12,7 @@ import demoCtaStyles from "@/src/components/homePageDemoCTA/homePageDemoCTA.modu
 import { trackButtonClick, trackSignupIntent } from "@/src/utils/PostHogTracking";
 import { GTagUTM } from "@/src/utils/GTagUTM";
 import { useGeoBypass } from "@/src/utils/useGeoBypass";
+import { localizeHref, stripLocalePrefix } from "@/src/utils/locale";
 
 export default function LinkedInOptimizationPage() {
   const router = useRouter();
@@ -93,8 +94,7 @@ export default function LinkedInOptimizationPage() {
       }
 
       const currentPath = pathname || (typeof window !== 'undefined' ? window.location.pathname : '');
-      const isAlreadyOnScheduleACareerCall = currentPath === '/schedule-a-free-career-call' ||
-        currentPath === '/en-ca/schedule-a-free-career-call';
+      const isAlreadyOnScheduleACareerCall = stripLocalePrefix(currentPath) === '/schedule-a-free-career-call';
 
       if (isAlreadyOnScheduleACareerCall) {
         return;
@@ -104,9 +104,7 @@ export default function LinkedInOptimizationPage() {
         sessionStorage.setItem('preserveScrollPosition', window.scrollY.toString());
       }
 
-      const targetPath = currentPath.startsWith('/en-ca')
-        ? '/en-ca/schedule-a-free-career-call'
-        : '/schedule-a-free-career-call';
+      const targetPath = localizeHref('/schedule-a-free-career-call', currentPath);
       router.push(targetPath);
     } catch (error) {
       console.warn('Error in Schedule Call handler:', error);
@@ -335,16 +333,11 @@ export default function LinkedInOptimizationPage() {
                     // Check current path first
                     const currentPath = pathname || (typeof window !== 'undefined' ? window.location.pathname : '');
                     const normalizedPath = currentPath.split('?')[0];
-                    const isAlreadyOnGetMeInterview = normalizedPath === '/get-me-interview' ||
-                      normalizedPath === '/en-ca/get-me-interview';
-                    const isOnLinkedInPage = normalizedPath === '/linkedin-profile-optimization-services' ||
-                      normalizedPath === '/en-ca/linkedin-profile-optimization-services' ||
-                      normalizedPath === '/features/linkedin-profile-optimization-services' ||
-                      normalizedPath === '/en-ca/features/linkedin-profile-optimization-services' ||
-                      normalizedPath === '/features/linkedin-profile-optimization' ||
-                      normalizedPath === '/en-ca/features/linkedin-profile-optimization' ||
-                      normalizedPath === '/features/linkedin-profile-optimization-tool' ||
-                      normalizedPath === '/en-ca/features/linkedin-profile-optimization-tool';
+                    const isAlreadyOnGetMeInterview = stripLocalePrefix(normalizedPath) === '/get-me-interview';
+                    const isOnLinkedInPage = stripLocalePrefix(normalizedPath) === '/linkedin-profile-optimization-services' ||
+                      stripLocalePrefix(normalizedPath) === '/features/linkedin-profile-optimization-services' ||
+                      stripLocalePrefix(normalizedPath) === '/features/linkedin-profile-optimization' ||
+                      stripLocalePrefix(normalizedPath) === '/features/linkedin-profile-optimization-tool';
 
                     // If already on the route, save scroll position and prevent navigation
                     if (isAlreadyOnGetMeInterview) {
@@ -378,7 +371,7 @@ export default function LinkedInOptimizationPage() {
                       
                       // Update URL for tracking without navigation
                       if (typeof window !== 'undefined') {
-                        const targetPath = normalizedPath.startsWith('/en-ca') ? '/en-ca/get-me-interview' : '/get-me-interview';
+                        const targetPath = localizeHref('/get-me-interview', normalizedPath);
                         window.history.pushState({}, '', targetPath);
                       }
                       

--- a/app/features/linkedin-profile-optimization/layout.tsx
+++ b/app/features/linkedin-profile-optimization/layout.tsx
@@ -8,6 +8,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/features/linkedin-profile-optimization",
       "en-CA": "https://www.flashfirejobs.com/en-ca/features/linkedin-profile-optimization",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/features/linkedin-profile-optimization",
       "x-default": "https://www.flashfirejobs.com/features/linkedin-profile-optimization",
     },
   },

--- a/app/features/linkedin-profile-optimization/page.tsx
+++ b/app/features/linkedin-profile-optimization/page.tsx
@@ -12,6 +12,7 @@ import styles from "@/src/components/homePageDemoCTA/homePageDemoCTA.module.css"
 import { trackButtonClick, trackSignupIntent } from "@/src/utils/PostHogTracking";
 import { GTagUTM } from "@/src/utils/GTagUTM";
 import { useGeoBypass } from "@/src/utils/useGeoBypass";
+import { localizeHref, isLocaleHome, stripLocalePrefix } from "@/src/utils/locale";
 
 export default function LinkedInOptimizationPage() {
   const router = useRouter();
@@ -232,16 +233,11 @@ export default function LinkedInOptimizationPage() {
                     // Check current path first
                     const currentPath = pathname || (typeof window !== 'undefined' ? window.location.pathname : '');
                     const normalizedPath = currentPath.split('?')[0];
-                    const isAlreadyOnGetMeInterview = normalizedPath === '/get-me-interview' ||
-                      normalizedPath === '/en-ca/get-me-interview';
-                    const isOnLinkedInPage = normalizedPath === '/linkedin-profile-optimization-services' ||
-                      normalizedPath === '/en-ca/linkedin-profile-optimization-services' ||
-                      normalizedPath === '/features/linkedin-profile-optimization-services' ||
-                      normalizedPath === '/en-ca/features/linkedin-profile-optimization-services' ||
-                      normalizedPath === '/features/linkedin-profile-optimization' ||
-                      normalizedPath === '/en-ca/features/linkedin-profile-optimization' ||
-                      normalizedPath === '/features/linkedin-profile-optimization-tool' ||
-                      normalizedPath === '/en-ca/features/linkedin-profile-optimization-tool';
+                    const isAlreadyOnGetMeInterview = stripLocalePrefix(normalizedPath) === '/get-me-interview';
+                    const isOnLinkedInPage = stripLocalePrefix(normalizedPath) === '/linkedin-profile-optimization-services' ||
+                      stripLocalePrefix(normalizedPath) === '/features/linkedin-profile-optimization-services' ||
+                      stripLocalePrefix(normalizedPath) === '/features/linkedin-profile-optimization' ||
+                      stripLocalePrefix(normalizedPath) === '/features/linkedin-profile-optimization-tool';
 
                     // If already on the route, save scroll position and prevent navigation
                     if (isAlreadyOnGetMeInterview) {
@@ -275,7 +271,7 @@ export default function LinkedInOptimizationPage() {
                       
                       // Update URL for tracking without navigation
                       if (typeof window !== 'undefined') {
-                        const targetPath = normalizedPath.startsWith('/en-ca') ? '/en-ca/get-me-interview' : '/get-me-interview';
+                        const targetPath = localizeHref('/get-me-interview', normalizedPath);
                         window.history.pushState({}, '', targetPath);
                       }
                       
@@ -677,16 +673,13 @@ export default function LinkedInOptimizationPage() {
               
               // Check current path
               const currentPath = pathname;
-              const isImageTestimonialsPage = currentPath === '/testimonials' || currentPath === '/en-ca/testimonials' || currentPath === '/image-testimonials' || currentPath === '/en-ca/image-testimonials';
-              const isAboutUsPage = currentPath === '/about-us' || currentPath === '/en-ca/about-us';
-              const isLinkedInPage = currentPath === '/linkedin-profile-optimization-services' || 
-                currentPath === '/en-ca/linkedin-profile-optimization-services' ||
-                currentPath === '/features/linkedin-profile-optimization-services' ||
-                currentPath === '/en-ca/features/linkedin-profile-optimization-services' ||
-                currentPath === '/features/linkedin-profile-optimization' ||
-                currentPath === '/en-ca/features/linkedin-profile-optimization';
-              const isAlreadyOnBookMyDemoCall = currentPath === '/book-my-demo-call' || currentPath === '/en-ca/book-my-demo-call';
-              const isOnHomePage = currentPath === '/' || currentPath === '/en-ca' || currentPath === '';
+              const isImageTestimonialsPage = stripLocalePrefix(currentPath) === '/testimonials' || stripLocalePrefix(currentPath) === '/image-testimonials';
+              const isAboutUsPage = stripLocalePrefix(currentPath) === '/about-us';
+              const isLinkedInPage = stripLocalePrefix(currentPath) === '/linkedin-profile-optimization-services' ||
+                stripLocalePrefix(currentPath) === '/features/linkedin-profile-optimization-services' ||
+                stripLocalePrefix(currentPath) === '/features/linkedin-profile-optimization';
+              const isAlreadyOnBookMyDemoCall = stripLocalePrefix(currentPath) === '/book-my-demo-call';
+              const isOnHomePage = isLocaleHome(currentPath) || currentPath === '';
               
               // If on home page, just show modal without navigating
               if (isOnHomePage) {
@@ -702,7 +695,7 @@ export default function LinkedInOptimizationPage() {
               // If on image-testimonials page, change URL but keep page content visible
               if (isImageTestimonialsPage) {
                 // Change URL to /book-my-demo-call without navigating (keep testimonials page visible)
-                const targetPath = currentPath.startsWith('/en-ca') ? '/en-ca/book-my-demo-call' : '/book-my-demo-call';
+                const targetPath = localizeHref('/book-my-demo-call', currentPath);
                 if (typeof window !== 'undefined') {
                   window.history.pushState({}, '', targetPath);
                 }
@@ -724,7 +717,7 @@ export default function LinkedInOptimizationPage() {
                 }
                 
                 // Change URL to /book-my-demo-call using pushState only (don't use router to prevent scroll)
-                const targetPath = currentPath.startsWith('/en-ca') ? '/en-ca/book-my-demo-call' : '/book-my-demo-call';
+                const targetPath = localizeHref('/book-my-demo-call', currentPath);
                 if (typeof window !== 'undefined') {
                   window.history.pushState({}, '', targetPath);
                 }
@@ -754,7 +747,7 @@ export default function LinkedInOptimizationPage() {
                 }
                 
                 // Change URL to /book-my-demo-call using pushState only (don't use router to prevent scroll)
-                const targetPath = currentPath.startsWith('/en-ca') ? '/en-ca/book-my-demo-call' : '/book-my-demo-call';
+                const targetPath = localizeHref('/book-my-demo-call', currentPath);
                 if (typeof window !== 'undefined') {
                   window.history.pushState({}, '', targetPath);
                 }

--- a/app/features/page.tsx
+++ b/app/features/page.tsx
@@ -12,6 +12,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/features",
       "en-CA": "https://www.flashfirejobs.com/en-ca/features",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/features",
       "x-default": "https://www.flashfirejobs.com/features",
     },
   },

--- a/app/features/precision-targeting/layout.tsx
+++ b/app/features/precision-targeting/layout.tsx
@@ -6,6 +6,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/features/precision-targeting",
       "en-CA": "https://www.flashfirejobs.com/en-ca/features/precision-targeting",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/features/precision-targeting",
       "x-default": "https://www.flashfirejobs.com/features/precision-targeting",
     },
   },

--- a/app/features/precision-targeting/page.tsx
+++ b/app/features/precision-targeting/page.tsx
@@ -8,6 +8,7 @@ import { Target, Search, Filter, Zap, CheckCircle, TrendingUp } from "lucide-rea
 import { trackButtonClick, trackSignupIntent } from "@/src/utils/PostHogTracking";
 import { GTagUTM } from "@/src/utils/GTagUTM";
 import { useGeoBypass } from "@/src/utils/useGeoBypass";
+import { localizeHref, stripLocalePrefix } from "@/src/utils/locale";
 
 export default function PrecisionTargetingPage() {
   const router = useRouter();
@@ -59,12 +60,9 @@ export default function PrecisionTargetingPage() {
       // Check current path first
       const currentPath = pathname || (typeof window !== 'undefined' ? window.location.pathname : '');
       const normalizedPath = currentPath.split('?')[0];
-      const isAlreadyOnGetMeInterview = normalizedPath === '/get-me-interview' ||
-        normalizedPath === '/en-ca/get-me-interview';
-      const isOnPrecisionTargetingPage = normalizedPath === '/features/precision-targeting' ||
-        normalizedPath === '/en-ca/features/precision-targeting' ||
-        normalizedPath === '/features/ai-job-targeting' ||
-        normalizedPath === '/en-ca/features/ai-job-targeting';
+      const isAlreadyOnGetMeInterview = stripLocalePrefix(normalizedPath) === '/get-me-interview';
+      const isOnPrecisionTargetingPage = stripLocalePrefix(normalizedPath) === '/features/precision-targeting' ||
+        stripLocalePrefix(normalizedPath) === '/features/ai-job-targeting';
 
       // If already on the route, save scroll position and prevent navigation
       if (isAlreadyOnGetMeInterview) {
@@ -98,7 +96,7 @@ export default function PrecisionTargetingPage() {
         
         // Update URL for tracking without navigation
         if (typeof window !== 'undefined') {
-          const targetPath = normalizedPath.startsWith('/en-ca') ? '/en-ca/get-me-interview' : '/get-me-interview';
+          const targetPath = localizeHref('/get-me-interview', normalizedPath);
           window.history.pushState({}, '', targetPath);
         }
         

--- a/app/features/resume-optimizer/layout.tsx
+++ b/app/features/resume-optimizer/layout.tsx
@@ -6,6 +6,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/features/resume-optimizer",
       "en-CA": "https://www.flashfirejobs.com/en-ca/features/resume-optimizer",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/features/resume-optimizer",
       "x-default": "https://www.flashfirejobs.com/features/resume-optimizer",
     },
   },

--- a/app/features/resume-optimizer/page.tsx
+++ b/app/features/resume-optimizer/page.tsx
@@ -25,6 +25,7 @@ import { trackButtonClick, trackSignupIntent } from "@/src/utils/PostHogTracking
 import { GTagUTM } from "@/src/utils/GTagUTM"
 import { useGeoBypass } from "@/src/utils/useGeoBypass"
 import Script from "next/script"
+import { localizeHref, stripLocalePrefix } from "@/src/utils/locale";
 
 // Minimal UI primitives (local) to avoid missing imports
 type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
@@ -211,14 +212,10 @@ export default function Page() {
       // Check current path first
       const currentPath = pathname || (typeof window !== 'undefined' ? window.location.pathname : '')
       const normalizedPath = currentPath.split('?')[0] // Remove query params
-      const isAlreadyOnGetMeInterview = normalizedPath === '/get-me-interview' ||
-        normalizedPath === '/en-ca/get-me-interview'
-      const isOnATSPage = normalizedPath === '/ats-optimized-resume-checker' ||
-        normalizedPath === '/en-ca/ats-optimized-resume-checker' ||
-        normalizedPath === '/features/resume-optimizer' ||
-        normalizedPath === '/en-ca/features/resume-optimizer' ||
-        normalizedPath === '/features/ats-optimizer' ||
-        normalizedPath === '/en-ca/features/ats-optimizer'
+      const isAlreadyOnGetMeInterview = stripLocalePrefix(normalizedPath) === '/get-me-interview'
+      const isOnATSPage = stripLocalePrefix(normalizedPath) === '/ats-optimized-resume-checker' ||
+        stripLocalePrefix(normalizedPath) === '/features/resume-optimizer' ||
+        stripLocalePrefix(normalizedPath) === '/features/ats-optimizer'
 
       // If already on the route, save scroll position and prevent navigation
       if (isAlreadyOnGetMeInterview) {
@@ -252,7 +249,7 @@ export default function Page() {
         
         // Update URL for tracking without navigation
         if (typeof window !== 'undefined') {
-          const targetPath = normalizedPath.startsWith('/en-ca') ? '/en-ca/get-me-interview' : '/get-me-interview'
+          const targetPath = localizeHref('/get-me-interview', normalizedPath)
           window.history.pushState({}, '', targetPath)
         }
         

--- a/app/get-me-interview/layout.tsx
+++ b/app/get-me-interview/layout.tsx
@@ -6,6 +6,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/get-me-interview",
       "en-CA": "https://www.flashfirejobs.com/en-ca/get-me-interview",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/get-me-interview",
       "x-default": "https://www.flashfirejobs.com/get-me-interview",
     },
   },

--- a/app/get-me-interview/page.tsx
+++ b/app/get-me-interview/page.tsx
@@ -11,6 +11,7 @@ import Navbar from "@/src/components/navbar/navbar";
 import Footer from "@/src/components/footer/footer";
 import AICopilot from "@/src/components/AICopilot/AICopilot";
 import dynamic from "next/dynamic";
+import { stripLocalePrefix } from "@/src/utils/locale";
 
 const ATSPage = dynamic(() => import("@/app/features/resume-optimizer/page"), {
   ssr: false,
@@ -88,8 +89,7 @@ export default function GetMeInterviewPage() {
         return <HomePage />;
     }
 
-    if (previousPage === '/AI-copilot' ||
-        previousPage === '/en-ca/AI-copilot') {
+    if (stripLocalePrefix(previousPage) === '/AI-copilot') {
         return (
             <>
                 <Navbar />
@@ -99,7 +99,7 @@ export default function GetMeInterviewPage() {
         );
     }
 
-    if (previousPage === '/about-us' || previousPage === '/en-ca/about-us') {
+    if (stripLocalePrefix(previousPage) === '/about-us') {
         return (
             <>
                 <Navbar />
@@ -109,8 +109,8 @@ export default function GetMeInterviewPage() {
         );
     }
 
-    if (previousPage === '/features' || previousPage === '/feature' || 
-        previousPage === '/en-ca/features' || previousPage === '/en-ca/feature') {
+    if (stripLocalePrefix(previousPage) === '/features' || stripLocalePrefix(previousPage) === '/feature' || 
+        stripLocalePrefix(previousPage) === '/features' || stripLocalePrefix(previousPage) === '/feature') {
         return (
             <>
                 <Navbar />
@@ -120,58 +120,44 @@ export default function GetMeInterviewPage() {
         );
     }
 
-    if (previousPage === '/features/resume-optimizer' ||
-        previousPage === '/en-ca/features/resume-optimizer' ||
-        previousPage === '/features/ats-optimizer' ||
-        previousPage === '/en-ca/features/ats-optimizer' ||
-        previousPage === '/ats-optimized-resume-checker' || 
-        previousPage === '/en-ca/ats-optimized-resume-checker') {
+    if (stripLocalePrefix(previousPage) === '/features/resume-optimizer' ||
+        stripLocalePrefix(previousPage) === '/features/ats-optimizer' ||
+        stripLocalePrefix(previousPage) === '/ats-optimized-resume-checker') {
         return <ATSPage />;
     }
 
-    if (previousPage === '/features/job-automation' ||
-        previousPage === '/en-ca/features/job-automation' ||
-        previousPage === '/job-application-automation' || 
-        previousPage === '/en-ca/job-application-automation') {
+    if (stripLocalePrefix(previousPage) === '/features/job-automation' ||
+        stripLocalePrefix(previousPage) === '/job-application-automation') {
         return <JobAutomationPage />;
     }
 
-    if (previousPage === '/features/linkedin-profile-optimization' ||
-        previousPage === '/en-ca/features/linkedin-profile-optimization' ||
-        previousPage === '/linkedin-profile-optimization-services' || 
-        previousPage === '/en-ca/linkedin-profile-optimization-services' ||
-        previousPage === '/features/linkedin-profile-optimization-services' ||
-        previousPage === '/en-ca/features/linkedin-profile-optimization-services') {
+    if (stripLocalePrefix(previousPage) === '/features/linkedin-profile-optimization' ||
+        stripLocalePrefix(previousPage) === '/linkedin-profile-optimization-services' ||
+        stripLocalePrefix(previousPage) === '/features/linkedin-profile-optimization-services') {
         return <LinkedInPage />;
     }
 
-    if (previousPage === '/features/job-tracker' ||
-        previousPage === '/en-ca/features/job-tracker') {
+    if (stripLocalePrefix(previousPage) === '/features/job-tracker') {
         return <JobTrackerPage />;
     }
 
-    if (previousPage === '/features/precision-targeting' ||
-        previousPage === '/en-ca/features/precision-targeting') {
+    if (stripLocalePrefix(previousPage) === '/features/precision-targeting') {
         return <PrecisionTargetingPage />;
     }
 
-    if (previousPage === '/features/dashboard-analytics' ||
-        previousPage === '/en-ca/features/dashboard-analytics') {
+    if (stripLocalePrefix(previousPage) === '/features/dashboard-analytics') {
         return <DashboardAnalyticsPage />;
     }
 
-    if (previousPage === '/features/cover-letter' ||
-        previousPage === '/en-ca/features/cover-letter') {
+    if (stripLocalePrefix(previousPage) === '/features/cover-letter') {
         return <CoverLetterPage />;
     }
 
-    if (previousPage === '/job-search' ||
-        previousPage === '/en-ca/job-search') {
+    if (stripLocalePrefix(previousPage) === '/job-search') {
         return <JobSearchPage />;
     }
 
-    if (previousPage === '/contact-us' ||
-        previousPage === '/en-ca/contact-us') {
+    if (stripLocalePrefix(previousPage) === '/contact-us') {
         return (
             <>
                 <Navbar />
@@ -181,8 +167,7 @@ export default function GetMeInterviewPage() {
         );
     }
 
-    if (previousPage === '/career-advisor' ||
-        previousPage === '/en-ca/career-advisor') {
+    if (stripLocalePrefix(previousPage) === '/career-advisor') {
         return (
             <>
                 <Navbar />
@@ -192,8 +177,7 @@ export default function GetMeInterviewPage() {
         );
     }
 
-    if (previousPage === '/interview-buddy' ||
-        previousPage === '/en-ca/interview-buddy') {
+    if (stripLocalePrefix(previousPage) === '/interview-buddy') {
         return (
             <>
                 <Navbar />

--- a/app/how-flashfire-ai-job-automation-platform-works/page.tsx
+++ b/app/how-flashfire-ai-job-automation-platform-works/page.tsx
@@ -14,6 +14,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/how-flashfire-ai-job-automation-platform-works",
       "en-CA": "https://www.flashfirejobs.com/en-ca/how-flashfire-ai-job-automation-platform-works",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/how-flashfire-ai-job-automation-platform-works",
       "x-default": "https://www.flashfirejobs.com/how-flashfire-ai-job-automation-platform-works",
     },
   },

--- a/app/image-testimonials/page.tsx
+++ b/app/image-testimonials/page.tsx
@@ -16,6 +16,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/image-testimonials",
       "en-CA": "https://www.flashfirejobs.com/en-ca/image-testimonials",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/image-testimonials",
       "x-default": "https://www.flashfirejobs.com/image-testimonials",
     },
   },

--- a/app/job-application-automation/JobApplicationAutomationContent.tsx
+++ b/app/job-application-automation/JobApplicationAutomationContent.tsx
@@ -4,6 +4,7 @@ import { useRouter, usePathname } from "next/navigation";
 import { trackButtonClick, trackSignupIntent } from "@/src/utils/PostHogTracking";
 import { GTagUTM } from "@/src/utils/GTagUTM";
 import { useGeoBypass } from "@/src/utils/useGeoBypass";
+import { localizeHref, stripLocalePrefix } from "@/src/utils/locale";
 
 export default function JobApplicationAutomationContent() {
   const router = useRouter();
@@ -55,11 +56,9 @@ export default function JobApplicationAutomationContent() {
       // Check current path first
       const currentPath = pathname || (typeof window !== 'undefined' ? window.location.pathname : '');
       const normalizedPath = currentPath.split('?')[0];
-      const isAlreadyOnGetMeInterview = normalizedPath === '/get-me-interview' ||
-        normalizedPath === '/en-ca/get-me-interview';
-      const isOnJobAutomationPage = normalizedPath === '/job-application-automation' ||
-        normalizedPath === '/en-ca/job-application-automation' ||
-        normalizedPath === '/Job-application-automation';
+      const isAlreadyOnGetMeInterview = stripLocalePrefix(normalizedPath) === '/get-me-interview';
+      const isOnJobAutomationPage = stripLocalePrefix(normalizedPath) === '/job-application-automation' ||
+        stripLocalePrefix(normalizedPath) === '/Job-application-automation';
 
       // If already on the route, save scroll position and prevent navigation
       if (isAlreadyOnGetMeInterview) {
@@ -95,7 +94,7 @@ export default function JobApplicationAutomationContent() {
           sessionStorage.setItem('preserveScrollPosition', currentScrollY.toString());
         }
 
-        const targetPath = normalizedPath.startsWith('/en-ca') ? '/en-ca/get-me-interview' : '/get-me-interview';
+        const targetPath = localizeHref('/get-me-interview', normalizedPath);
         router.replace(targetPath);
         return;
       }
@@ -137,7 +136,7 @@ export default function JobApplicationAutomationContent() {
     // Fallback: Navigate to the How It Works page if section not found
     const currentPath = pathname || (typeof window !== 'undefined' ? window.location.pathname : '');
     const normalizedPath = currentPath.split('?')[0];
-    const targetPath = normalizedPath.startsWith('/en-ca') ? '/en-ca/how-it-works' : '/how-it-works';
+    const targetPath = localizeHref('/how-it-works', normalizedPath);
     router.push(targetPath);
   };
   

--- a/app/job-application-automation/page.tsx
+++ b/app/job-application-automation/page.tsx
@@ -6,6 +6,7 @@ import Footer from "@/src/components/footer/footer";
 import { trackButtonClick, trackSignupIntent } from "@/src/utils/PostHogTracking";
 import { GTagUTM } from "@/src/utils/GTagUTM";
 import { useGeoBypass } from "@/src/utils/useGeoBypass";
+import { localizeHref, stripLocalePrefix } from "@/src/utils/locale";
 
 export default function JobApplicationAutomationPage() {
   const router = useRouter();
@@ -57,10 +58,8 @@ export default function JobApplicationAutomationPage() {
       // Check current path first
       const currentPath = pathname || (typeof window !== 'undefined' ? window.location.pathname : '');
       const normalizedPath = currentPath.split('?')[0];
-      const isAlreadyOnGetMeInterview = normalizedPath === '/get-me-interview' ||
-        normalizedPath === '/en-ca/get-me-interview';
-      const isOnJobAutomationPage = normalizedPath === '/job-application-automation' ||
-        normalizedPath === '/en-ca/job-application-automation';
+      const isAlreadyOnGetMeInterview = stripLocalePrefix(normalizedPath) === '/get-me-interview';
+      const isOnJobAutomationPage = stripLocalePrefix(normalizedPath) === '/job-application-automation';
 
       // If already on the route, save scroll position and prevent navigation
       if (isAlreadyOnGetMeInterview) {
@@ -96,7 +95,7 @@ export default function JobApplicationAutomationPage() {
           sessionStorage.setItem('preserveScrollPosition', currentScrollY.toString());
         }
 
-        const targetPath = normalizedPath.startsWith('/en-ca') ? '/en-ca/get-me-interview' : '/get-me-interview';
+        const targetPath = localizeHref('/get-me-interview', normalizedPath);
         router.replace(targetPath);
         return;
       }
@@ -138,7 +137,7 @@ export default function JobApplicationAutomationPage() {
     // Fallback: Navigate to the How It Works page if section not found
     const currentPath = pathname || (typeof window !== 'undefined' ? window.location.pathname : '');
     const normalizedPath = currentPath.split('?')[0];
-    const targetPath = normalizedPath.startsWith('/en-ca') ? '/en-ca/how-it-works' : '/how-it-works';
+    const targetPath = localizeHref('/how-it-works', normalizedPath);
     router.push(targetPath);
   };
   return (

--- a/app/job-search/page.tsx
+++ b/app/job-search/page.tsx
@@ -16,6 +16,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/job-search",
       "en-CA": "https://www.flashfirejobs.com/en-ca/job-search",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/job-search",
       "x-default": "https://www.flashfirejobs.com/job-search",
     },
   },

--- a/app/linkedin-profile-optimization-services/LinkedInOptimizationContent.tsx
+++ b/app/linkedin-profile-optimization-services/LinkedInOptimizationContent.tsx
@@ -9,6 +9,7 @@ import styles from "@/src/components/homePageDemoCTA/homePageDemoCTA.module.css"
 import { trackButtonClick, trackSignupIntent } from "@/src/utils/PostHogTracking";
 import { GTagUTM } from "@/src/utils/GTagUTM";
 import { useGeoBypass } from "@/src/utils/useGeoBypass";
+import { localizeHref, isLocaleHome, stripLocalePrefix } from "@/src/utils/locale";
 
 export default function LinkedInOptimizationContent() {
   const router = useRouter();
@@ -116,11 +117,9 @@ export default function LinkedInOptimizationContent() {
                     // Check current path first
                     const currentPath = pathname || (typeof window !== 'undefined' ? window.location.pathname : '');
                     const normalizedPath = currentPath.split('?')[0];
-                    const isAlreadyOnGetMeInterview = normalizedPath === '/get-me-interview' ||
-                      normalizedPath === '/en-ca/get-me-interview';
-                    const isOnLinkedInPage = normalizedPath === '/linkedin-profile-optimization-services' ||
-                      normalizedPath === '/en-ca/linkedin-profile-optimization-services' ||
-                      normalizedPath === '/Linkedin-Profile-Optimization-Services';
+                    const isAlreadyOnGetMeInterview = stripLocalePrefix(normalizedPath) === '/get-me-interview';
+                    const isOnLinkedInPage = stripLocalePrefix(normalizedPath) === '/linkedin-profile-optimization-services' ||
+                      stripLocalePrefix(normalizedPath) === '/Linkedin-Profile-Optimization-Services';
 
                     // If already on the route, save scroll position and prevent navigation
                     if (isAlreadyOnGetMeInterview) {
@@ -156,7 +155,7 @@ export default function LinkedInOptimizationContent() {
                         sessionStorage.setItem('preserveScrollPosition', currentScrollY.toString());
                       }
 
-                      const targetPath = normalizedPath.startsWith('/en-ca') ? '/en-ca/get-me-interview' : '/get-me-interview';
+                      const targetPath = localizeHref('/get-me-interview', normalizedPath);
                       router.replace(targetPath);
                       return;
                     }
@@ -204,7 +203,7 @@ export default function LinkedInOptimizationContent() {
                   // Fallback: Navigate to the How It Works page if section not found
                   const currentPath = pathname || (typeof window !== 'undefined' ? window.location.pathname : '');
                   const normalizedPath = currentPath.split('?')[0];
-                  const targetPath = normalizedPath.startsWith('/en-ca') ? '/en-ca/how-it-works' : '/how-it-works';
+                  const targetPath = localizeHref('/how-it-works', normalizedPath);
                   router.push(targetPath);
                 }}
                 className="border-2 border-[#ff4c00] text-[#ff4c00] bg-transparent hover:bg-[#fff2ea] px-6 sm:px-8 py-3 sm:py-4 font-semibold text-base sm:text-lg transition-colors rounded-lg inline-flex items-center justify-center"
@@ -516,11 +515,11 @@ export default function LinkedInOptimizationContent() {
               
               // Check current path
               const currentPath = pathname;
-              const isImageTestimonialsPage = currentPath === '/testimonials' || currentPath === '/en-ca/testimonials' || currentPath === '/image-testimonials' || currentPath === '/en-ca/image-testimonials';
-              const isAboutUsPage = currentPath === '/about-us' || currentPath === '/en-ca/about-us';
-              const isLinkedInPage = currentPath === '/linkedin-profile-optimization-services' || currentPath === '/en-ca/linkedin-profile-optimization-services' || currentPath === '/Linkedin-Profile-Optimization-Services';
-              const isAlreadyOnBookMyDemoCall = currentPath === '/book-my-demo-call' || currentPath === '/en-ca/book-my-demo-call';
-              const isOnHomePage = currentPath === '/' || currentPath === '/en-ca' || currentPath === '';
+              const isImageTestimonialsPage = stripLocalePrefix(currentPath) === '/testimonials' || stripLocalePrefix(currentPath) === '/image-testimonials';
+              const isAboutUsPage = stripLocalePrefix(currentPath) === '/about-us';
+              const isLinkedInPage = stripLocalePrefix(currentPath) === '/linkedin-profile-optimization-services' || stripLocalePrefix(currentPath) === '/Linkedin-Profile-Optimization-Services';
+              const isAlreadyOnBookMyDemoCall = stripLocalePrefix(currentPath) === '/book-my-demo-call';
+              const isOnHomePage = isLocaleHome(currentPath) || currentPath === '';
               
               // If on home page, just show modal without navigating
               if (isOnHomePage) {
@@ -536,7 +535,7 @@ export default function LinkedInOptimizationContent() {
               // If on image-testimonials page, change URL but keep page content visible
               if (isImageTestimonialsPage) {
                 // Change URL to /book-my-demo-call without navigating (keep testimonials page visible)
-                const targetPath = currentPath.startsWith('/en-ca') ? '/en-ca/book-my-demo-call' : '/book-my-demo-call';
+                const targetPath = localizeHref('/book-my-demo-call', currentPath);
                 if (typeof window !== 'undefined') {
                   window.history.pushState({}, '', targetPath);
                 }
@@ -558,7 +557,7 @@ export default function LinkedInOptimizationContent() {
                 }
                 
                 // Change URL to /book-my-demo-call using pushState only (don't use router to prevent scroll)
-                const targetPath = currentPath.startsWith('/en-ca') ? '/en-ca/book-my-demo-call' : '/book-my-demo-call';
+                const targetPath = localizeHref('/book-my-demo-call', currentPath);
                 if (typeof window !== 'undefined') {
                   window.history.pushState({}, '', targetPath);
                 }
@@ -588,7 +587,7 @@ export default function LinkedInOptimizationContent() {
                 }
                 
                 // Change URL to /book-my-demo-call using pushState only (don't use router to prevent scroll)
-                const targetPath = currentPath.startsWith('/en-ca') ? '/en-ca/book-my-demo-call' : '/book-my-demo-call';
+                const targetPath = localizeHref('/book-my-demo-call', currentPath);
                 if (typeof window !== 'undefined') {
                   window.history.pushState({}, '', targetPath);
                 }

--- a/app/offer-and-salary-negotiation-advisor/layout.tsx
+++ b/app/offer-and-salary-negotiation-advisor/layout.tsx
@@ -6,6 +6,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/offer-and-salary-negotiation-advisor",
       "en-CA": "https://www.flashfirejobs.com/en-ca/offer-and-salary",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/offer-and-salary",
       "x-default": "https://www.flashfirejobs.com/offer-and-salary-negotiation-advisor",
     },
   },

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -14,6 +14,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/pricing",
       "en-CA": "https://www.flashfirejobs.com/en-ca/pricing",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/pricing",
       "x-default": "https://www.flashfirejobs.com/pricing",
     },
   },

--- a/app/recent-job-openings/page.tsx
+++ b/app/recent-job-openings/page.tsx
@@ -14,6 +14,7 @@ export const metadata: Metadata = {
         languages: {
             "en-US": "https://www.flashfirejobs.com/recent-job-openings",
             "en-CA": "https://www.flashfirejobs.com/en-ca/recent-job-openings",
+            "en-GB": "https://www.flashfirejobs.com/en-uk/recent-job-openings",
             "x-default": "https://www.flashfirejobs.com/recent-job-openings",
         },
     },

--- a/app/see-flashfire-in-action/page.tsx
+++ b/app/see-flashfire-in-action/page.tsx
@@ -15,6 +15,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/see-flashfire-in-action",
       "en-CA": "https://www.flashfirejobs.com/en-ca/see-flashfire-in-action",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/see-flashfire-in-action",
       "x-default": "https://www.flashfirejobs.com/see-flashfire-in-action",
     },
   },

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -140,5 +140,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { url: `${baseUrl}/en-ca/talk-to-an-expert`, lastModified: new Date('2025-11-01'), changeFrequency: 'monthly' as const, priority: 0.5 },
   ]
 
-  return [...staticRoutes, ...canadaRoutes, ...blogUrls]
+  // The UK tree mirrors the Canada tree exactly, so derive it rather than
+  // maintaining a second hand-written list that can drift.
+  const ukRoutes: MetadataRoute.Sitemap = canadaRoutes.map((route) => ({
+    ...route,
+    url: route.url.replace(`${baseUrl}/en-ca`, `${baseUrl}/en-uk`),
+  }))
+
+  return [...staticRoutes, ...canadaRoutes, ...ukRoutes, ...blogUrls]
 }

--- a/app/testimonials/page.tsx
+++ b/app/testimonials/page.tsx
@@ -17,6 +17,7 @@ export const metadata: Metadata = {
     languages: {
       "en-US": "https://www.flashfirejobs.com/testimonials",
       "en-CA": "https://www.flashfirejobs.com/en-ca/testimonials",
+      "en-GB": "https://www.flashfirejobs.com/en-uk/testimonials",
       "x-default": "https://www.flashfirejobs.com/testimonials",
     },
   },

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
+import { CANADA_PREFIX, UK_PREFIX, LOCALE_PREFIXES, UK_EU_COUNTRY_CODES } from '@/src/utils/locale';
 
 const CANADA_CODE = 'CA';
-const STORAGE_KEY = 'ff_country_code_v1';
 
 // Cache for country codes (in-memory for server-side)
 const countryCache = new Map<string, { code: string; expiresAt: number }>();
@@ -56,15 +56,31 @@ function getClientIp(request: NextRequest): string | null {
   return null;
 }
 
+/** Language tags that imply a UK/EU visitor when no IP geolocation is available. */
+const UK_EU_LANGUAGE_TAGS = [
+  'en-GB', 'en-IE',
+  'de-DE', 'de-AT', 'fr-FR', 'fr-BE', 'nl-NL', 'nl-BE', 'it-IT', 'es-ES',
+  'pt-PT', 'pl-PL', 'sv-SE', 'da-DK', 'fi-FI', 'el-GR', 'cs-CZ', 'sk-SK',
+  'hu-HU', 'ro-RO', 'bg-BG', 'hr-HR', 'sl-SI', 'et-EE', 'lv-LV', 'lt-LT',
+  'mt-MT', 'ga-IE',
+];
+
 function detectCountryFallback(request: NextRequest): string {
   // Try to detect from Accept-Language header
   const acceptLanguage = request.headers.get('accept-language') || '';
-  
+
   // Check for French Canadian
   if (acceptLanguage.includes('fr-CA')) {
     return 'CA';
   }
-  
+
+  // Check for a UK/EU locale. Return the matching region so the caller's
+  // UK_EU_COUNTRY_CODES lookup routes it to /en-uk.
+  const ukEuTag = UK_EU_LANGUAGE_TAGS.find(tag => acceptLanguage.includes(tag));
+  if (ukEuTag) {
+    return ukEuTag.split('-')[1];
+  }
+
   // Default to US
   return 'US';
 }
@@ -89,8 +105,8 @@ export async function middleware(request: NextRequest) {
     return NextResponse.next();
   }
 
-  // If already on /en-ca path, allow it
-  if (pathname.startsWith('/en-ca')) {
+  // If already inside a locale tree (/en-ca, /en-uk), allow it
+  if (LOCALE_PREFIXES.some(prefix => pathname === prefix || pathname.startsWith(`${prefix}/`))) {
     return NextResponse.next();
   }
 
@@ -129,8 +145,16 @@ export async function middleware(request: NextRequest) {
     // Redirect to /en-ca if Canada detected
     if (countryCode === CANADA_CODE) {
       const url = request.nextUrl.clone();
-      url.pathname = '/en-ca';
+      url.pathname = CANADA_PREFIX;
       console.log('[Middleware] Redirecting to /en-ca for Canada user');
+      return NextResponse.redirect(url);
+    }
+
+    // Redirect to /en-uk for the UK and every EU member state
+    if (countryCode && UK_EU_COUNTRY_CODES.has(countryCode)) {
+      const url = request.nextUrl.clone();
+      url.pathname = UK_PREFIX;
+      console.log(`[Middleware] Redirecting to /en-uk for ${countryCode} user`);
       return NextResponse.redirect(url);
     }
   }

--- a/next.config.ts
+++ b/next.config.ts
@@ -168,6 +168,11 @@ const nextConfig: NextConfig = {
         permanent: true,
       },
       {
+        source: "/en-uk/blogs",
+        destination: "/en-uk/blog",
+        permanent: true,
+      },
+      {
         source: "/feature",
         destination: "/features",
         permanent: true,
@@ -230,6 +235,11 @@ const nextConfig: NextConfig = {
         permanent: true,
       },
       {
+        source: "/en-uk/features/ats-optimizer",
+        destination: "/en-uk/features/resume-optimizer",
+        permanent: true,
+      },
+      {
         source: "/job-application-automation",
         destination: "/features/job-automation",
         permanent: true,
@@ -252,6 +262,11 @@ const nextConfig: NextConfig = {
       {
         source: "/en-ca/how-it-works",
         destination: "/en-ca/how-flashfire-ai-job-automation-platform-works",
+        permanent: true,
+      },
+      {
+        source: "/en-uk/how-it-works",
+        destination: "/en-uk/how-flashfire-ai-job-automation-platform-works",
         permanent: true,
       },
     ];

--- a/src/components/AICopilot/AICopilot.tsx
+++ b/src/components/AICopilot/AICopilot.tsx
@@ -7,6 +7,7 @@ import { useState } from "react";
 import { trackButtonClick, trackExternalLink } from "@/src/utils/PostHogTracking";
 import { WHATSAPP_SUPPORT_URL } from "@/src/utils/whatsapp";
 import HomePageHappyUsers from "../homePageHappyUsers/homePageHappyUsers";
+import { getLocalePrefix } from "@/src/utils/locale";
 
 const dispatchCustomEvent = (eventName: string) => {
   if (typeof window !== "undefined") {
@@ -19,7 +20,7 @@ export default function AICopilot() {
 
   const router = useRouter();
   const pathname = usePathname();
-  const prefix = pathname.startsWith("/en-ca") ? "/en-ca" : "";
+  const prefix = getLocalePrefix(pathname);
 
 
   const handleStartApplyingClick = (target: "modal" | "cta" = "modal") => {

--- a/src/components/BlackFridayPopup.tsx
+++ b/src/components/BlackFridayPopup.tsx
@@ -8,7 +8,7 @@ export default function BlackFridayPopup() {
   const [isVisible, setIsVisible] = useState(false);
   const [mounted, setMounted] = useState(false);
   const pathname = usePathname();
-  const isImageTestimonialsPage = pathname === "/testimonials" || pathname === "/en-ca/testimonials" || pathname === "/image-testimonials" || pathname === "/en-ca/image-testimonials";
+  const isImageTestimonialsPage = pathname === "/testimonials" || pathname === "/en-ca/testimonials" || pathname === "/en-uk/testimonials" || pathname === "/image-testimonials" || pathname === "/en-ca/image-testimonials";
 
   useEffect(() => {
     // Only run on client side

--- a/src/components/ClientLogicWrapper.tsx
+++ b/src/components/ClientLogicWrapper.tsx
@@ -13,6 +13,7 @@ import MeetingBookedModal from "@/src/components/meetingBooked/MeetingBookedModa
 import * as fbq from "@/lib/metaPixel";
 import * as linkedin from "@/lib/linkedinInsightTag";
 import { warmCalendly } from "@/src/utils/calendlyWarmup";
+import { stripLocalePrefix } from "@/src/utils/locale";
 
 function ClientLogicWrapperContent({
     children,
@@ -269,7 +270,7 @@ function ClientLogicWrapperContent({
         const isBookNow = pathname === '/book-now';
         const isSignup = pathname === '/signup' || pathname.includes('/signup');
         const isBookDemo = pathname === '/book-free-demo' || pathname.includes('/book-free-demo');
-        const isMeetingBooked = pathname === '/meeting-booked' || pathname === '/en-ca/meeting-booked';
+        const isMeetingBooked = stripLocalePrefix(pathname) === '/meeting-booked';
 
         // Create a unique identifier for this route visit (includes query params)
         const currentRouteKey = `${pathname}${searchParams.toString() ? `?${searchParams.toString()}` : ''}`;
@@ -401,7 +402,7 @@ function ClientLogicWrapperContent({
         setShowCalendlyModal(false);
         
         // If we came from a specific page (features, pricing, etc.), navigate back to it
-        if (typeof window !== "undefined" && (pathname === '/book-now' || pathname === '/en-ca/book-now')) {
+        if (typeof window !== "undefined" && stripLocalePrefix(pathname) === '/book-now') {
             const previousPage = sessionStorage.getItem('previousPageBeforeBookNow');
             if (previousPage) {
                 // Clear the stored previous page
@@ -414,7 +415,7 @@ function ClientLogicWrapperContent({
         }
         
         // Clean URL by removing query params when on /book-now
-        if ((pathname === '/book-now' || pathname === '/en-ca/book-now') && searchParams.toString()) {
+        if (stripLocalePrefix(pathname) === '/book-now' && searchParams.toString()) {
             router.replace(pathname);
         }
     };

--- a/src/components/PostHogProvider.tsx
+++ b/src/components/PostHogProvider.tsx
@@ -5,6 +5,7 @@ import { useEffect, Suspense } from "react";
 import { usePathname, useSearchParams } from "next/navigation";
 import { captureUTMParams } from "@/src/utils/captureUTMParams";
 import { apiUrl } from "@/src/utils/apiBase";
+import { getLocale } from "@/src/utils/locale";
 
 // Inner component to handle pageview tracking. Renders nothing itself —
 // mounted alongside (not around) page content so it can suspend on
@@ -28,9 +29,11 @@ function PostHogPageView() {
       }
       
       // Get country context
-      const isCanada = pathname.startsWith("/en-ca");
-      const countryCode = typeof window !== "undefined" 
-        ? localStorage.getItem("ff_country_code_v1") || (isCanada ? "CA" : "US")
+      const locale = getLocale(pathname);
+      const isCanada = locale === "ca";
+      const localeFallbackCode = isCanada ? "CA" : locale === "uk" ? "GB" : "US";
+      const countryCode = typeof window !== "undefined"
+        ? localStorage.getItem("ff_country_code_v1") || localeFallbackCode
         : "US";
       
       // Get UTM parameters
@@ -55,7 +58,8 @@ function PostHogPageView() {
         $current_url: url,
         country_code: countryCode,
         is_canada: isCanada,
-        locale: isCanada ? "en-ca" : "en-us",
+        is_uk: locale === "uk",
+        locale: locale === "uk" ? "en-uk" : isCanada ? "en-ca" : "en-us",
         utm_source: utmSource || "direct",
         utm_medium: utmMedium || "website",
         utm_campaign: utmCampaign || "organic",

--- a/src/components/aiCareerAssessment/AICareerAssessment.tsx
+++ b/src/components/aiCareerAssessment/AICareerAssessment.tsx
@@ -3,12 +3,12 @@
 import { Brain, ClipboardList, TrendingUp, Target, Users, CheckCircle2, ArrowRight, FileText, BarChart3, Award, Clock, Shield } from "lucide-react";
 import { FaPlus, FaTimes } from "react-icons/fa";
 import { useState } from "react";
+import { getLocalePrefix } from "@/src/utils/locale";
 
 const updateCtaUrl = (basePath: string, label: string) => {
   if (typeof window === "undefined") return;
   const slug = label.trim().replace(/\s+/g, "-");
-  const isCanada = window.location.pathname.startsWith("/en-ca");
-  const normalizedBase = isCanada ? `/en-ca${basePath}` : basePath;
+  const normalizedBase = `${getLocalePrefix(window.location.pathname)}${basePath}`;
   const newUrl = `${normalizedBase}/${slug}`;
   window.history.pushState({}, "", newUrl);
   window.dispatchEvent(new CustomEvent("showStrategyCallCard"));

--- a/src/components/aiFollowUpEmails/AIFollowUpEmails.tsx
+++ b/src/components/aiFollowUpEmails/AIFollowUpEmails.tsx
@@ -3,6 +3,7 @@
 import { MailCheck, Clock, Sparkles, FileText, Mail, Users, CheckCircle2, ArrowRight } from "lucide-react";
 import { FaPlus, FaTimes } from "react-icons/fa";
 import { useState } from "react";
+import { getLocalePrefix } from "@/src/utils/locale";
 
 export default function AIFollowUpEmailsPage() {
   const ctaLabel = "Generate Email";
@@ -11,8 +12,7 @@ export default function AIFollowUpEmailsPage() {
   const updateCtaUrl = (basePath: string, label: string) => {
     if (typeof window === "undefined") return;
     const slug = label.trim().replace(/\s+/g, "-");
-    const isCanada = window.location.pathname.startsWith("/en-ca");
-    const normalizedBase = isCanada ? `/en-ca${basePath}` : basePath;
+    const normalizedBase = `${getLocalePrefix(window.location.pathname)}${basePath}`;
     const newUrl = `${normalizedBase}/${slug}`;
     window.history.pushState({}, "", newUrl);
     window.dispatchEvent(new CustomEvent("showStrategyCallCard"));

--- a/src/components/aiJobAlerts/AIJobAlerts.tsx
+++ b/src/components/aiJobAlerts/AIJobAlerts.tsx
@@ -4,12 +4,12 @@ import {
 } from "lucide-react";
 import { FaPlus, FaTimes } from "react-icons/fa";
 import { useState } from "react";
+import { getLocalePrefix } from "@/src/utils/locale";
 
 const updateCtaUrl = (basePath: string, label: string) => {
   if (typeof window === "undefined") return;
   const slug = label.trim().replace(/\s+/g, "-");
-  const isCanada = window.location.pathname.startsWith("/en-ca");
-  const normalizedBase = isCanada ? `/en-ca${basePath}` : basePath;
+  const normalizedBase = `${getLocalePrefix(window.location.pathname)}${basePath}`;
   const newUrl = `${normalizedBase}/${slug}`;
   window.history.pushState({}, "", newUrl);
   window.dispatchEvent(new CustomEvent("showStrategyCallCard"));

--- a/src/components/aiJobMatchingPlatform/AIJobMatchingPlatform.tsx
+++ b/src/components/aiJobMatchingPlatform/AIJobMatchingPlatform.tsx
@@ -4,12 +4,12 @@ import { Target, Sparkles, Users, CheckCircle, Award, UserCheck, TrendingUp, Fil
 import { FaPlus, FaTimes } from "react-icons/fa";
 import { useState } from "react";
 import Link from "next/link";
+import { getLocalePrefix } from "@/src/utils/locale";
 
 const updateCtaUrl = (basePath: string, label: string) => {
   if (typeof window === "undefined") return;
   const slug = label.trim().replace(/\s+/g, "-");
-  const isCanada = window.location.pathname.startsWith("/en-ca");
-  const normalizedBase = isCanada ? `/en-ca${basePath}` : basePath;
+  const normalizedBase = `${getLocalePrefix(window.location.pathname)}${basePath}`;
   const newUrl = `${normalizedBase}/${slug}`;
   window.history.pushState({}, "", newUrl);
   window.dispatchEvent(new CustomEvent("showStrategyCallCard"));

--- a/src/components/aiJobSearchFreshers/AIJobSearchFreshers.tsx
+++ b/src/components/aiJobSearchFreshers/AIJobSearchFreshers.tsx
@@ -3,12 +3,12 @@
 import { GraduationCap, Search, Target, Sparkles, ArrowRight, CheckCircle2, Briefcase, TrendingUp, Shield, Zap } from "lucide-react";
 import { FaPlus, FaTimes } from "react-icons/fa";
 import { useState } from "react";
+import { getLocalePrefix } from "@/src/utils/locale";
 
 const updateCtaUrl = (basePath: string, label: string) => {
   if (typeof window === "undefined") return;
   const slug = label.trim().replace(/\s+/g, "-");
-  const isCanada = window.location.pathname.startsWith("/en-ca");
-  const normalizedBase = isCanada ? `/en-ca${basePath}` : basePath;
+  const normalizedBase = `${getLocalePrefix(window.location.pathname)}${basePath}`;
   const newUrl = `${normalizedBase}/${slug}`;
   window.history.pushState({}, "", newUrl);
   window.dispatchEvent(new CustomEvent("showStrategyCallCard"));

--- a/src/components/aiRemoteJobSearch/AIRemoteJobSearch.tsx
+++ b/src/components/aiRemoteJobSearch/AIRemoteJobSearch.tsx
@@ -35,12 +35,12 @@ import {
   Rocket
 } from "lucide-react";
 import { useState } from "react";
+import { getLocalePrefix } from "@/src/utils/locale";
 
 const updateCtaUrl = (basePath: string, label: string) => {
   if (typeof window === "undefined") return;
   const slug = label.trim().replace(/\s+/g, "-");
-  const isCanada = window.location.pathname.startsWith("/en-ca");
-  const normalizedBase = isCanada ? `/en-ca${basePath}` : basePath;
+  const normalizedBase = `${getLocalePrefix(window.location.pathname)}${basePath}`;
   const newUrl = `${normalizedBase}/${slug}`;
   window.history.pushState({}, "", newUrl);
   window.dispatchEvent(new CustomEvent("showStrategyCallCard"));

--- a/src/components/aiResumeBuilder/AIResumeBuilder.tsx
+++ b/src/components/aiResumeBuilder/AIResumeBuilder.tsx
@@ -3,12 +3,12 @@
 import { CheckCircle, FileText, Sparkles, Briefcase, Target, TrendingUp, Award, BarChart3, Users } from "lucide-react";
 import { FaPlus, FaTimes } from "react-icons/fa";
 import { useState } from "react";
+import { getLocalePrefix } from "@/src/utils/locale";
 
 const updateCtaUrl = (basePath: string, label: string) => {
   if (typeof window === "undefined") return;
   const slug = label.trim().replace(/\s+/g, "-");
-  const isCanada = window.location.pathname.startsWith("/en-ca");
-  const normalizedBase = isCanada ? `/en-ca${basePath}` : basePath;
+  const normalizedBase = `${getLocalePrefix(window.location.pathname)}${basePath}`;
   const newUrl = `${normalizedBase}/${slug}`;
   window.history.pushState({}, "", newUrl);
   window.dispatchEvent(new CustomEvent("showStrategyCallCard"));

--- a/src/components/careerAdvisor/careerAdvisor.tsx
+++ b/src/components/careerAdvisor/careerAdvisor.tsx
@@ -8,6 +8,7 @@ import { GTagUTM } from "@/src/utils/GTagUTM";
 import { useState } from "react";
 import { FaPlus, FaTimes } from "react-icons/fa";
 import styles from "@/src/components/homePageFAQ/homePageFAQ.module.css";
+import { localizeHref } from "@/src/utils/locale";
 
 export default function CareerAdvisor() {
   const [activeFaq, setActiveFaq] = useState<number | null>(null);
@@ -67,12 +68,7 @@ export default function CareerAdvisor() {
 
   const pushCustomUrl = (path?: string) => {
     if (typeof window === "undefined" || !path) return;
-    const isCanada = window.location.pathname.startsWith("/en-ca");
-    const normalized = path.startsWith("/en-ca")
-      ? path
-      : isCanada
-        ? `/en-ca${path}`
-        : path;
+    const normalized = localizeHref(path, window.location.pathname);
     window.history.pushState({}, "", normalized);
   };
 

--- a/src/components/contactUs/contactUsClient.tsx
+++ b/src/components/contactUs/contactUsClient.tsx
@@ -8,6 +8,7 @@ import { Copy, Check } from "lucide-react";
 import { trackButtonClick, trackSignupIntent } from "@/src/utils/PostHogTracking";
 import { GTagUTM } from "@/src/utils/GTagUTM";
 import { FaPlus, FaTimes } from "react-icons/fa";
+import { stripLocalePrefix, localizeHref } from "@/src/utils/locale";
 
 
 
@@ -84,11 +85,9 @@ export default function ContactUsClient() {
         (typeof window !== "undefined" ? window.location.pathname : "");
       const normalizedPath = currentPath.split("?")[0];
       const isAlreadyOnGetMeInterview =
-        normalizedPath === "/schedule-a-demo-with-flashfire" ||
-        normalizedPath === "/en-ca/schedule-a-demo-with-flashfire";
+        stripLocalePrefix(normalizedPath) === "/schedule-a-demo-with-flashfire";
       const isOnContactUsPage =
-        normalizedPath === "/contact-us" ||
-        normalizedPath === "/en-ca/contact-us";
+        stripLocalePrefix(normalizedPath) === "/contact-us";
 
       // If already on get-me-interview, just show modal
       if (isAlreadyOnGetMeInterview) {
@@ -131,9 +130,7 @@ export default function ContactUsClient() {
           );
         }
 
-        const targetPath = normalizedPath.startsWith("/en-ca")
-          ? "/en-ca/schedule-a-demo-with-flashfire"
-          : "/schedule-a-demo-with-flashfire";
+        const targetPath = localizeHref("/schedule-a-demo-with-flashfire", normalizedPath);
         router.replace(targetPath);
         return;
       }

--- a/src/components/countries/uk/Home.tsx
+++ b/src/components/countries/uk/Home.tsx
@@ -1,0 +1,73 @@
+"use client";
+import { useEffect } from "react";
+import { usePathname } from "next/navigation";
+import Footer from "@/src/components/footer/footer";
+import HeroSection from "@/src/components/heroSection/heroSection";
+import HomePageCareerCTA from "@/src/components/homePageCareerCTA/homePageCareerCTA";
+import HomePageDemoCTA from "@/src/components/homePageDemoCTA/homePageDemoCTA";
+import HomePageFAQ from "@/src/components/homePageFAQ/homePageFAQ";
+import HomePageFoundersNote from "@/src/components/homePageFoundersNote/homePageFoundersNote";
+import HomePageHappyUsers from "@/src/components/homePageHappyUsers/homePageHappyUsers";
+import HomePageMilestones from "@/src/components/homePageMilestones/homePageMilestones";
+import HomePageOfferLetters from "@/src/components/homePageOfferLetters/homePageOfferLetters";
+import HomePagePTNote from "@/src/components/homePagePTNote/homePagePTNote";
+import HomePageResultStats from "@/src/components/homePageResultStats/homePageResultStats";
+import HomePageStatsCards from "@/src/components/homePageStatsCards/homePageStatsCards";
+import HomePageSteps from "@/src/components/homePageSteps/homePageSteps";
+import HomePageJobMatchingSection from "@/src/components/homePageJobMatchingSection/homePageJobMatchingSection";
+import HomePageVideo from "@/src/components/homePageVideo/homePageVideo";
+import HomePageWhyChooseFF from "@/src/components/homePageWhyChooseFF/homePageWhyChooseFF";
+import Navbar from "@/src/components/navbar/navbar";
+import HomePageBeforeAfter from "../../homePageBeforeAfter/homePageBeforeAfter";
+import { UK_PREFIX } from "@/src/utils/locale";
+
+export default function UKHome() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    // Scroll to top when navigating to the UK home page
+    const isUKHomePage = pathname === UK_PREFIX;
+
+    if (isUKHomePage) {
+      // Use requestAnimationFrame to ensure DOM is ready
+      requestAnimationFrame(() => {
+        window.scrollTo({ top: 0, behavior: "instant" });
+
+        // Also scroll after a short delay to catch any late scrolls from browser restoration
+        setTimeout(() => {
+          window.scrollTo({ top: 0, behavior: "instant" });
+        }, 50);
+
+        // One more check after layout
+        requestAnimationFrame(() => {
+          setTimeout(() => {
+            window.scrollTo({ top: 0, behavior: "instant" });
+          }, 100);
+        });
+      });
+    }
+  }, [pathname]);
+
+  return (
+    <>
+      <Navbar />
+      <HeroSection />
+      <HomePageStatsCards />
+      <HomePageSteps />
+      <HomePageJobMatchingSection />
+      <HomePageCareerCTA />
+      <HomePageBeforeAfter />
+      <HomePageResultStats />
+      <HomePageOfferLetters />
+      <HomePageMilestones />
+      <HomePageVideo />
+      <HomePageWhyChooseFF />
+      <HomePageHappyUsers />
+      <HomePageFoundersNote />
+      <HomePagePTNote />
+      <HomePageFAQ />
+      <HomePageDemoCTA />
+      <Footer />
+    </>
+  );
+}

--- a/src/components/footer/footer.tsx
+++ b/src/components/footer/footer.tsx
@@ -4,13 +4,13 @@ import { usePathname, useRouter } from "next/navigation";
 import Link from "next/link";
 import { FaLinkedinIn, FaInstagram, FaYoutube } from "react-icons/fa";
 import { smoothScrollToElement } from "@/src/utils/smoothScroll";
+import { getLocalePrefix, isLocaleHome } from "@/src/utils/locale";
 
 export default function Footer() {
   const pathname = usePathname();
   const router = useRouter();
 
-  const isCanadaContext = pathname.startsWith("/en-ca");
-  const prefix = isCanadaContext ? "/en-ca" : "";
+  const prefix = getLocalePrefix(pathname);
 
   const getHref = (href: string) => {
     if (href.startsWith("http")) return href;
@@ -21,8 +21,7 @@ export default function Footer() {
 
   const handleFAQClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
     e.preventDefault();
-    const isHome =
-      pathname === "/" || pathname === "/en-ca" || pathname === `${prefix}/`;
+    const isHome = isLocaleHome(pathname);
 
     if (isHome) {
       setTimeout(() => {

--- a/src/components/heroSection/heroSection.tsx
+++ b/src/components/heroSection/heroSection.tsx
@@ -1,18 +1,24 @@
 "use client";
 
 import { usePathname } from "next/navigation";
-import { heroSectionData, heroSectionDataCA } from "@/src/data/herosection";
+import { heroSectionData, heroSectionDataCA, heroSectionDataUK } from "@/src/data/herosection";
 import HeroSectionClient from "./heroSectionClient";
+import { getLocale, type Locale } from "@/src/utils/locale";
 
 type Props = {
-  country?: "us" | "ca";
+  country?: Locale;
 };
 
 export default function HeroSection({ country }: Props) {
   const pathname = usePathname();
-  const isCanadaContext =
-    country === "ca" || (country !== "us" && pathname?.startsWith("/en-ca"));
-  const data = isCanadaContext ? heroSectionDataCA : heroSectionData;
+  // An explicit `country` prop wins; otherwise infer it from the route.
+  const locale: Locale = country ?? getLocale(pathname);
+  const data =
+    locale === "uk"
+      ? heroSectionDataUK
+      : locale === "ca"
+        ? heroSectionDataCA
+        : heroSectionData;
   const heroImageSrc = "/images/landingpageImg.png";
 
   return (

--- a/src/components/homePageCareerCTA/homePageCareerCTA.tsx
+++ b/src/components/homePageCareerCTA/homePageCareerCTA.tsx
@@ -8,6 +8,7 @@ import { trackButtonClick, trackSignupIntent } from "@/src/utils/PostHogTracking
 import { GTagUTM } from "@/src/utils/GTagUTM";
 import { useGeoBypass } from "@/src/utils/useGeoBypass";
 import { useEffect, useState } from "react";
+import { stripLocalePrefix } from "@/src/utils/locale";
 
 export default function HomePageCareerCTA() {
   const router = useRouter();
@@ -96,8 +97,7 @@ export default function HomePageCareerCTA() {
                 // Check current path first
                 const currentPath = pathname || (typeof window !== 'undefined' ? window.location.pathname : '');
                 const normalizedPath = currentPath.split('?')[0]; // Remove query params
-                const isAlreadyOnScheduleACareerCall = normalizedPath === '/schedule-a-free-career-call' ||
-                  normalizedPath === '/en-ca/schedule-a-free-career-call';
+                const isAlreadyOnScheduleACareerCall = stripLocalePrefix(normalizedPath) === '/schedule-a-free-career-call';
 
                 // Navigate to /schedule-a-free-career-call WITHOUT exposing UTM params in the URL
                 const targetPath = '/schedule-a-free-career-call';

--- a/src/components/homePageDemoCTA/homePageDemoCTA.tsx
+++ b/src/components/homePageDemoCTA/homePageDemoCTA.tsx
@@ -8,6 +8,7 @@ import styles from "./homePageDemoCTA.module.css";
 import { trackButtonClick, trackSignupIntent } from "@/src/utils/PostHogTracking";
 import { GTagUTM } from "@/src/utils/GTagUTM";
 import { useGeoBypass } from "@/src/utils/useGeoBypass";
+import { stripLocalePrefix, isLocaleHome, localizeHref } from "@/src/utils/locale";
 
 export default function HomePageDemoCTA() {
   const router = useRouter();
@@ -143,10 +144,10 @@ export default function HomePageDemoCTA() {
 
                   // Check current path
                   const currentPath = pathname;
-                  const isImageTestimonialsPage = currentPath === '/testimonials' || currentPath === '/en-ca/testimonials' || currentPath === '/image-testimonials' || currentPath === '/en-ca/image-testimonials';
-                  const isAboutUsPage = currentPath === '/about-us' || currentPath === '/en-ca/about-us';
-                  const isAlreadyOnScheduleACareerCall = currentPath === '/schedule-a-free-career-call' || currentPath === '/en-ca/schedule-a-free-career-call';
-                  const isOnHomePage = currentPath === '/' || currentPath === '/en-ca' || currentPath === '';
+                  const isImageTestimonialsPage = stripLocalePrefix(currentPath) === '/testimonials' || stripLocalePrefix(currentPath) === '/image-testimonials';
+                  const isAboutUsPage = stripLocalePrefix(currentPath) === '/about-us';
+                  const isAlreadyOnScheduleACareerCall = stripLocalePrefix(currentPath) === '/schedule-a-free-career-call';
+                  const isOnHomePage = isLocaleHome(currentPath) || currentPath === '';
 
                   console.log('Button clicked - currentPath:', currentPath, 'isOnHomePage:', isOnHomePage);
 
@@ -164,7 +165,7 @@ export default function HomePageDemoCTA() {
                   // If on image-testimonials page, change URL but keep page content visible
                   if (isImageTestimonialsPage) {
                     // Change URL to /schedule-a-free-career-call without navigating (keep testimonials page visible)
-                    const targetPath = currentPath.startsWith('/en-ca') ? '/en-ca/schedule-a-free-career-call' : '/schedule-a-free-career-call';
+                    const targetPath = localizeHref('/schedule-a-free-career-call', currentPath);
                     if (typeof window !== 'undefined') {
                       window.history.pushState({}, '', targetPath);
                     }
@@ -186,7 +187,7 @@ export default function HomePageDemoCTA() {
                     }
 
                     // Change URL to /schedule-a-free-career-call using pushState only (don't use router to prevent scroll)
-                    const targetPath = currentPath.startsWith('/en-ca') ? '/en-ca/schedule-a-free-career-call' : '/schedule-a-free-career-call';
+                    const targetPath = localizeHref('/schedule-a-free-career-call', currentPath);
                     if (typeof window !== 'undefined') {
                       window.history.pushState({}, '', targetPath);
                     }

--- a/src/components/homePageHappyUsers/homePageHappyUsers.tsx
+++ b/src/components/homePageHappyUsers/homePageHappyUsers.tsx
@@ -6,6 +6,7 @@ import { useState, useEffect, useRef } from "react";
 import React from "react";
 import CachedTestimonialImage from "./CachedTestimonialImage";
 import styles from "./homePageHappyUsers.module.css";
+import { getLocalePrefix } from "@/src/utils/locale";
 
 // Helper function to optimize Cloudinary URLs for fast loading
 const optimizeCloudinaryUrl = (url: string, width: number = 800) => {
@@ -88,8 +89,7 @@ export default function HomePageHappyUsers({
   variant = "default",
 }: HomePageHappyUsersProps) {
   const pathname = usePathname();
-  const isCanadaContext = pathname.startsWith("/en-ca");
-  const prefix = isCanadaContext ? "/en-ca" : "";
+  const prefix = getLocalePrefix(pathname);
 
   const handleTryItYourself = () => {
     if (typeof window === "undefined") {

--- a/src/components/homePagePricingPlans/homePagePricingPlans.tsx
+++ b/src/components/homePagePricingPlans/homePagePricingPlans.tsx
@@ -4,59 +4,90 @@ import { useState, useMemo, useRef, useEffect } from "react";
 import { usePathname } from "next/navigation";
 import PricingCard from "./pricingCard";
 import Image from "next/image";
-import { usPricingPlans, canadaPricingPlans } from "@/src/data/pricingData";
+import { usPricingPlans, canadaPricingPlans, ukPricingPlans, type PricingPlan } from "@/src/data/pricingData";
+import { getLocale } from "@/src/utils/locale";
+
+/** A plan shown in the "Upgrade Plan" panel, priced as the delta from the current tier. */
+type UpgradeOption = PricingPlan & {
+  upgradePrice: number;
+  upgradePaymentUrl?: string;
+};
 
 interface UpgradePrice {
   from: string;
   to: string;
   price: number;
+  /** Upgrade price in GBP for `/en-uk`, when different from US */
+  ukPrice?: number;
   paymentUrl?: string;
   /** Stripe checkout for `/en-ca` when different from US */
   canadaPaymentUrl?: string;
+  /**
+   * Stripe checkout for `/en-uk`.
+   * TODO(payments): points at the USD checkout until GBP links exist.
+   */
+  ukPaymentUrl?: string;
 }
 
+// UK upgrade prices are the exact difference between the GBP tier prices.
 const upgradePrices: UpgradePrice[] = [
   {
     from: "PRIME",
     to: "PROFESSIONAL",
     price: 240,
+    ukPrice: 220,
     paymentUrl: "https://buy.stripe.com/7sY7sN2128uS1DWdcz3AY08",
     canadaPaymentUrl: "https://buy.stripe.com/bJe28t9tu26u96o5K73AY0q",
+    ukPaymentUrl: "https://buy.stripe.com/7sY7sN2128uS1DWdcz3AY08",
   },
   {
     from: "PRIME",
     to: "EXECUTIVE",
     price: 490,
+    ukPrice: 420,
     paymentUrl: "https://buy.stripe.com/fZu3cx6hi9yW82k0pN3AY09",
     canadaPaymentUrl: "https://buy.stripe.com/6oU8wRcFG4eC5Uc1tR3AY0r",
+    ukPaymentUrl: "https://buy.stripe.com/fZu3cx6hi9yW82k0pN3AY09",
   },
   {
     from: "IGNITE",
     to: "PROFESSIONAL",
     price: 170,
+    ukPrice: 150,
     paymentUrl: "https://buy.stripe.com/28E6oJ9tu7qOfuM3BZ3AY0d",
     canadaPaymentUrl: "https://buy.stripe.com/00w9AV212eTg6YgfkH3AY0n",
+    ukPaymentUrl: "https://buy.stripe.com/28E6oJ9tu7qOfuM3BZ3AY0d",
   },
   {
     from: "IGNITE",
     to: "EXECUTIVE",
     price: 420,
+    ukPrice: 350,
     paymentUrl: "https://buy.stripe.com/5kQcN7eNO7qO2I06Ob3AY0e",
     canadaPaymentUrl: "https://buy.stripe.com/fZu5kF9tueTg82kc8v3AY0v",
+    ukPaymentUrl: "https://buy.stripe.com/5kQcN7eNO7qO2I06Ob3AY0e",
   },
   {
     from: "PROFESSIONAL",
     to: "EXECUTIVE",
     price: 285,
+    ukPrice: 200,
     paymentUrl: "https://buy.stripe.com/00w7sNgVW4eCbew1tR3AY0f",
     canadaPaymentUrl: "https://buy.stripe.com/5kQ5kF212aD0eqIfkH3AY0x",
+    ukPaymentUrl: "https://buy.stripe.com/00w7sNgVW4eCbew1tR3AY0f",
   },
 ];
 
 export default function HomePagePricingPlans() {
   const pathname = usePathname();
-  const isCanadaContext = pathname.startsWith("/en-ca");
-  const pricingPlans = isCanadaContext ? canadaPricingPlans : usPricingPlans;
+  const locale = getLocale(pathname);
+  const isCanadaContext = locale === "ca";
+  const isUKContext = locale === "uk";
+  const pricingPlans = isUKContext
+    ? ukPricingPlans
+    : isCanadaContext
+      ? canadaPricingPlans
+      : usPricingPlans;
   const [selectedPlanForUpgrade, setSelectedPlanForUpgrade] = useState<string | null>(null);
   const [selectedPlanIndex, setSelectedPlanIndex] = useState<number | null>(null);
   const [selectedPlanForBooster, setSelectedPlanForBooster] = useState<string | null>(null);
@@ -67,7 +98,7 @@ export default function HomePagePricingPlans() {
   const shouldScrollBoosterRef = useRef<boolean>(false);
   const shouldScrollUpgradeRef = useRef<boolean>(false);
 
-  const currencySymbol = isCanadaContext ? "CA$" : "$";
+  const currencySymbol = isUKContext ? "£" : isCanadaContext ? "CA$" : "$";
 
   const openCheckout = (paymentUrl?: string) => {
     if (!paymentUrl || typeof window === "undefined") {
@@ -77,7 +108,7 @@ export default function HomePagePricingPlans() {
     const checkoutWindow = window.open(paymentUrl, "_blank", "noopener,noreferrer");
 
     if (!checkoutWindow) {
-      window.location.href = paymentUrl;
+      window.location.assign(paymentUrl);
     }
   };
 
@@ -152,16 +183,16 @@ export default function HomePagePricingPlans() {
   }, [selectedPlanForUpgrade, selectedPlanIndex]);
 
   // Get upgrade options for the selected plan
-  const upgradeOptions = useMemo(() => {
+  const upgradeOptions = useMemo<UpgradeOption[]>(() => {
     if (!selectedPlanForUpgrade) return [];
-    
+
     const planHierarchy = ["PRIME", "IGNITE", "PROFESSIONAL", "EXECUTIVE"];
     const currentPlanIndex = planHierarchy.indexOf(selectedPlanForUpgrade);
-    
+
     if (currentPlanIndex === -1 || currentPlanIndex === planHierarchy.length - 1) {
       return [];
     }
-    
+
     return pricingPlans
       .filter(plan => {
         const planIndex = planHierarchy.indexOf(plan.title);
@@ -175,18 +206,22 @@ export default function HomePagePricingPlans() {
         const upgradePriceConfig = upgradePrices.find(
           up => up.from === selectedPlanForUpgrade && up.to === plan.title
         );
-        const upgradePrice = upgradePriceConfig?.price || 0;
-        const upgradePaymentUrl = isCanadaContext
-          ? upgradePriceConfig?.canadaPaymentUrl ?? upgradePriceConfig?.paymentUrl
-          : upgradePriceConfig?.paymentUrl;
-        
+        const upgradePrice = isUKContext
+          ? upgradePriceConfig?.ukPrice ?? upgradePriceConfig?.price ?? 0
+          : upgradePriceConfig?.price || 0;
+        const upgradePaymentUrl = isUKContext
+          ? upgradePriceConfig?.ukPaymentUrl ?? upgradePriceConfig?.paymentUrl
+          : isCanadaContext
+            ? upgradePriceConfig?.canadaPaymentUrl ?? upgradePriceConfig?.paymentUrl
+            : upgradePriceConfig?.paymentUrl;
+
         return {
           ...plan,
           upgradePrice: upgradePrice,
           upgradePaymentUrl: upgradePaymentUrl,
         };
       });
-  }, [selectedPlanForUpgrade, pricingPlans, isCanadaContext]);
+  }, [selectedPlanForUpgrade, pricingPlans, isCanadaContext, isUKContext]);
 
   const handleUpgradeClick = (planTitle: string, planIndex: number) => {
     if (selectedPlanForUpgrade === planTitle) {
@@ -258,7 +293,7 @@ export default function HomePagePricingPlans() {
   const boosterOptions = useMemo(() => {
     if (!selectedPlanForBooster) return [];
     
-    const country = isCanadaContext ? "CA" : "US";
+    const country = isUKContext ? "UK" : isCanadaContext ? "CA" : "US";
     const planBoosterOptions: Record<string, Record<string, Array<{
       applications: number;
       price: number;
@@ -309,10 +344,36 @@ export default function HomePagePricingPlans() {
           { applications: 1000, price: 460, label: "+1000 Extra Applications", paymentUrl: "https://buy.stripe.com/eVqaEZ3565iG3M4dcz3AY0A" },
         ],
       },
+      // GBP add-ons. Rates fall as the bundle grows and are cheapest on
+      // EXECUTIVE, mirroring how the US/CA ladders are structured.
+      // TODO(payments): paymentUrl values are the USD checkouts until GBP
+      // links exist — see UK_STRIPE_LINKS in src/data/pricingData.ts.
+      UK: {
+        PRIME: [
+          { applications: 250, price: 95, label: "+250 Extra Applications", paymentUrl: "https://buy.stripe.com/dRmeVf7lm8uSaas6Ob3AY05" },
+          { applications: 500, price: 160, label: "+500 Extra Applications", paymentUrl: "https://buy.stripe.com/28E5kF3567qObewegD3AY06" },
+          { applications: 1000, price: 275, label: "+1000 Extra Applications", paymentUrl: "https://buy.stripe.com/00w28t35626udmE2xV3AY07" },
+        ],
+        IGNITE: [
+          { applications: 250, price: 105, label: "+250 Extra Applications", paymentUrl: "https://buy.stripe.com/28E7sN9tufXk6Yga0n3AY0a" },
+          { applications: 500, price: 175, label: "+500 Extra Applications", paymentUrl: "https://buy.stripe.com/eVqaEZ5debH4fuM7Sf3AY0b" },
+          { applications: 1000, price: 300, label: "+1000 Extra Applications", paymentUrl: "https://buy.stripe.com/9B69AVfRS6mKdmEgoL3AY0c" },
+        ],
+        PROFESSIONAL: [
+          { applications: 250, price: 95, label: "+250 Extra Applications", paymentUrl: "https://buy.stripe.com/dRmeVf7lm8uSaas6Ob3AY05" },
+          { applications: 500, price: 160, label: "+500 Extra Applications", paymentUrl: "https://buy.stripe.com/28E5kF3567qObewegD3AY06" },
+          { applications: 1000, price: 275, label: "+1000 Extra Applications", paymentUrl: "https://buy.stripe.com/00w28t35626udmE2xV3AY07" },
+        ],
+        EXECUTIVE: [
+          { applications: 250, price: 88, label: "+250 Extra Applications", paymentUrl: "https://buy.stripe.com/28EfZj9tu9yW2I0goL3AY0g" },
+          { applications: 500, price: 150, label: "+500 Extra Applications", paymentUrl: "https://buy.stripe.com/fZu6oJdJK7qObew1tR3AY0h" },
+          { applications: 1000, price: 260, label: "+1000 Extra Applications", paymentUrl: "https://buy.stripe.com/4gM5kF9tu6mK1DW3BZ3AY0i" },
+        ],
+      },
     };
     
     return planBoosterOptions[country]?.[selectedPlanForBooster] || [];
-  }, [selectedPlanForBooster, isCanadaContext]);
+  }, [selectedPlanForBooster, isCanadaContext, isUKContext]);
 
   return (
     <section
@@ -450,7 +511,7 @@ export default function HomePagePricingPlans() {
                         <button
                           key={upgradePlan.title}
                           onClick={() => {
-                            const paymentUrl = (upgradePlan as any).upgradePaymentUrl || upgradePlan.paymentLink;
+                            const paymentUrl = upgradePlan.upgradePaymentUrl || upgradePlan.paymentLink;
                             openCheckout(paymentUrl);
                           }}
                           className="w-full text-left p-3 rounded-md border transition-all duration-200 bg-[#fffaf7] border-[#ffb99d] text-black hover:bg-[#fff1e9] hover:border-[#ff4c00]"
@@ -465,7 +526,7 @@ export default function HomePagePricingPlans() {
                               </div>
                             </div>
                             <div className="font-bold text-xs sm:text-sm flex-shrink-0">
-                              {currencySymbol}{(upgradePlan as any).upgradePrice || 0}
+                              {currencySymbol}{upgradePlan.upgradePrice || 0}
                             </div>
                           </div>
                         </button>
@@ -576,7 +637,7 @@ export default function HomePagePricingPlans() {
                         <button
                           key={upgradePlan.title}
                           onClick={() => {
-                            const paymentUrl = (upgradePlan as any).upgradePaymentUrl || upgradePlan.paymentLink;
+                            const paymentUrl = upgradePlan.upgradePaymentUrl || upgradePlan.paymentLink;
                             openCheckout(paymentUrl);
                           }}
                           className="w-full text-left p-3 rounded-md border transition-all duration-200 bg-[#fffaf7] border-[#ffb99d] text-black hover:bg-[#fff1e9] hover:border-[#ff4c00]"
@@ -591,7 +652,7 @@ export default function HomePagePricingPlans() {
                               </div>
                             </div>
                             <div className="font-bold text-xs sm:text-sm flex-shrink-0">
-                              {currencySymbol}{(upgradePlan as any).upgradePrice || 0}
+                              {currencySymbol}{upgradePlan.upgradePrice || 0}
                             </div>
                           </div>
                         </button>

--- a/src/components/homePagePricingPlans/pricingCard.tsx
+++ b/src/components/homePagePricingPlans/pricingCard.tsx
@@ -85,7 +85,7 @@ export default function PricingCard({
     });
   }, [title, allPlans]);
 
-  // Parse base price from string (handles "$199" or "CA$279")
+  // Parse base price from string (handles "$199", "CA$279" or "£149")
   const basePrice = useMemo(() => {
     const priceMatch = price.match(/[\d.]+/);
     return priceMatch ? parseFloat(priceMatch[0]) : 0;
@@ -105,9 +105,12 @@ export default function PricingCard({
     return Math.round(discount);
   }, [oldBasePrice, basePrice]);
 
-  // Get currency symbol
+  // Get currency symbol. Check the multi-character prefixes first so "CA$" is
+  // not matched as a plain "$".
   const currencySymbol = useMemo(() => {
     if (price.includes("CA$")) return "CA$";
+    if (price.includes("£")) return "£";
+    if (price.includes("€")) return "€";
     if (price.includes("$")) return "$";
     return "$";
   }, [price]);

--- a/src/components/interviewBuddy/interviewBuddy.tsx
+++ b/src/components/interviewBuddy/interviewBuddy.tsx
@@ -7,6 +7,7 @@ import Image from "next/image";
 import { useGeoBypass } from "@/src/utils/useGeoBypass";
 import { GTagUTM } from "@/src/utils/GTagUTM";
 import { trackButtonClick, trackSignupIntent } from "@/src/utils/PostHogTracking";
+import { localizeHref } from "@/src/utils/locale";
 
 export default function InterviewBuddy() {
     const { getButtonProps } = useGeoBypass({
@@ -16,12 +17,7 @@ export default function InterviewBuddy() {
     });
     const pushCustomUrl = (path?: string) => {
             if (typeof window === "undefined" || !path) return;
-            const isCanada = window.location.pathname.startsWith("/en-ca");
-            const normalized = path.startsWith("/en-ca")
-              ? path
-              : isCanada
-              ? `/en-ca${path}`
-              : path;
+            const normalized = localizeHref(path, window.location.pathname);
             window.history.pushState({}, "", normalized);
           };
     return (

--- a/src/components/jobApplicationStatusTracker/JobApplicationStatusTracker.tsx
+++ b/src/components/jobApplicationStatusTracker/JobApplicationStatusTracker.tsx
@@ -3,12 +3,12 @@
 import { ListChecks, CalendarCheck, BarChart3, Send, MessageSquare, CalendarClock, CheckCircle, TrendingUp, ArrowRight, Sparkles, X, FileText, Clock, Filter, Tag, Shield, Smartphone, Zap, Target, Brain, Database, Globe, LayoutDashboard, Bell, Search, ChevronDown } from "lucide-react";
 import { FaPlus, FaTimes } from "react-icons/fa";
 import { useState } from "react";
+import { getLocalePrefix } from "@/src/utils/locale";
 
 const updateCtaUrl = (basePath: string, label: string) => {
   if (typeof window === "undefined") return;
   const slug = label.trim().replace(/\s+/g, "-");
-  const isCanada = window.location.pathname.startsWith("/en-ca");
-  const normalizedBase = isCanada ? `/en-ca${basePath}` : basePath;
+  const normalizedBase = `${getLocalePrefix(window.location.pathname)}${basePath}`;
   const newUrl = `${normalizedBase}/${slug}`;
   window.history.pushState({}, "", newUrl);
   window.dispatchEvent(new CustomEvent("showStrategyCallCard"));

--- a/src/components/navbar/navbarClient.tsx
+++ b/src/components/navbar/navbarClient.tsx
@@ -11,6 +11,7 @@ import { GTagUTM } from "@/src/utils/GTagUTM";
 import { useRouter } from "next/navigation";
 import { useGeoBypass } from "@/src/utils/useGeoBypass";
 import { smoothScrollToElement, smoothScrollTo } from "@/src/utils/smoothScroll";
+import { getLocalePrefix, stripLocalePrefix, isLocaleHome } from "@/src/utils/locale";
 
 
 type Props = {
@@ -44,15 +45,14 @@ export default function NavbarClient({ links, ctas }: Props) {
   });
   const pathname = usePathname();
   const safePathname = pathname || (typeof window !== 'undefined' ? window.location.pathname : '') || '';
-  const isCanadaContext = safePathname.startsWith("/en-ca");
-  const prefix = isCanadaContext ? "/en-ca" : "";
+  const prefix = getLocalePrefix(safePathname);
+  // Compare against the locale-stripped path so /en-ca and /en-uk behave alike.
+  const basePathname = stripLocalePrefix(safePathname);
 
-  const isImageTestimonialsPage = safePathname === "/testimonials" || safePathname === "/en-ca/testimonials" || safePathname === "/image-testimonials" || safePathname === "/en-ca/image-testimonials";
+  const isImageTestimonialsPage = basePathname === "/testimonials" || basePathname === "/image-testimonials";
   const isBlogsPage =
-    safePathname.startsWith("/blogs") ||
-    safePathname.startsWith("/blog") ||
-    safePathname.startsWith("/en-ca/blogs") ||
-    safePathname.startsWith("/en-ca/blog");
+    basePathname.startsWith("/blogs") ||
+    basePathname.startsWith("/blog");
 
   const isExternalHref = (href: string) => href.startsWith("http");
 
@@ -127,7 +127,7 @@ export default function NavbarClient({ links, ctas }: Props) {
             easing: 'easeInOutCubic',
           });
         }, 100);
-      } else if (currentPath === '/' || currentPath === '/en-ca') {
+      } else if (isLocaleHome(currentPath)) {
         smoothScrollTo(0, {
           duration: 600,
           easing: 'easeOutCubic',
@@ -185,11 +185,11 @@ export default function NavbarClient({ links, ctas }: Props) {
             {/* Left Section: Logo */}
             <div className={styles.navLeft}>
               <Link
-                href={isCanadaContext ? "/en-ca" : "/"}
+                href={prefix || "/"}
                 className={styles.navLogoText}
                 onClick={(e) => {
                   const currentPath = pathname;
-                  const isOnHomePage = currentPath === "/" || currentPath === "/en-ca" || currentPath === prefix + "/";
+                  const isOnHomePage = isLocaleHome(currentPath);
 
                   if (isOnHomePage) {
                     e.preventDefault();
@@ -210,8 +210,8 @@ export default function NavbarClient({ links, ctas }: Props) {
               {links.map((link) => {
                 const sectionLinks: string[] = [];
                 const isSectionLink = sectionLinks.includes(link.href);
-                const isOnHomePage = pathname === '/' || pathname === '/en-ca' || pathname === prefix + '/';
-                const isOnPricingPage = pathname === '/pricing' || pathname === '/en-ca/pricing' || pathname === prefix + '/pricing';
+                const isOnHomePage = isLocaleHome(pathname);
+                const isOnPricingPage = stripLocalePrefix(pathname) === '/pricing';
                 const isOnSectionPage = pathname === getHref(link.href) || pathname === link.href || pathname === prefix + link.href;
                 const isExternal = isExternalHref(link.href) || link.target === "_blank";
                 const isFeaturesLink = link.name.toLowerCase() === "features";
@@ -425,7 +425,7 @@ export default function NavbarClient({ links, ctas }: Props) {
                             router.push(prefix + '/');
                             const scrollToSectionOnHome = () => {
                               const currentPath = window.location.pathname;
-                              const isNowOnHome = currentPath === '/' || currentPath === '/en-ca' || currentPath === prefix + '/';
+                              const isNowOnHome = isLocaleHome(currentPath);
                               if (isNowOnHome) {
                                 const sectionId = link.href.replace('/', '');
                                 const section = document.getElementById(sectionId);
@@ -499,7 +499,7 @@ export default function NavbarClient({ links, ctas }: Props) {
 
             {/* Right Section: CTAs (Desktop) */}
             <div className={styles.navRight}>
-              {ctas.primary && (ctas.primary.href === "/Get-Started" || ctas.primary.href === "/en-ca/Get-Started") ? (
+              {ctas.primary && (stripLocalePrefix(ctas.primary.href) === "/Get-Started") ? (
                 <Link
                   href={getHref(ctas.primary.href)}
                   className={styles.navPrimaryButton}
@@ -547,8 +547,8 @@ export default function NavbarClient({ links, ctas }: Props) {
                 {links.map((link) => {
                   const sectionLinks: string[] = [];
                   const isSectionLink = sectionLinks.includes(link.href);
-                  const isOnHomePage = safePathname === '/' || safePathname === '/en-ca' || safePathname === prefix + '/';
-                  const isOnPricingPage = safePathname === '/pricing' || safePathname === '/en-ca/pricing' || safePathname === prefix + '/pricing';
+                  const isOnHomePage = isLocaleHome(safePathname);
+                  const isOnPricingPage = stripLocalePrefix(safePathname) === '/pricing';
                   const isOnSectionPage = safePathname === getHref(link.href) || safePathname === link.href || safePathname === prefix + link.href;
                   const isExternal = isExternalHref(link.href) || link.target === "_blank";
                   const isFeaturesLink = link.name.toLowerCase() === "features";
@@ -837,7 +837,7 @@ export default function NavbarClient({ links, ctas }: Props) {
                               router.push(prefix + '/');
                               const scrollToSectionOnHome = () => {
                                 const currentPath = window.location.pathname;
-                                const isNowOnHome = currentPath === '/' || currentPath === '/en-ca' || currentPath === prefix + '/';
+                                const isNowOnHome = isLocaleHome(currentPath);
                                 if (isNowOnHome) {
                                   const sectionId = link.href.replace('/', '');
                                   const section = document.getElementById(sectionId);
@@ -924,8 +924,7 @@ export default function NavbarClient({ links, ctas }: Props) {
         {/* Mobile Bottom Book a Demo CTA */}
         {!isMenuOpen &&
           ctas.primary &&
-          (ctas.primary.href === "/Get-Started" ||
-            ctas.primary.href === "/en-ca/Get-Started") && (
+          stripLocalePrefix(ctas.primary.href) === "/Get-Started" && (
             <div className={styles.navMobileButtonsSticky}>
 
               <Link

--- a/src/components/offerAndSalary/offerAndSalary.tsx
+++ b/src/components/offerAndSalary/offerAndSalary.tsx
@@ -18,6 +18,7 @@ import Image from "next/image";
 import { useGeoBypass } from "@/src/utils/useGeoBypass";
 import { trackButtonClick, trackSignupIntent } from "@/src/utils/PostHogTracking";
 import { GTagUTM } from "@/src/utils/GTagUTM";
+import { localizeHref } from "@/src/utils/locale";
 
 export default function SalaryNegotiationUI() {
     const { getButtonProps } = useGeoBypass({
@@ -28,10 +29,7 @@ export default function SalaryNegotiationUI() {
 
     const pushCustomUrl = (path?: string) => {
         if (typeof window === "undefined" || !path) return;
-        const isCanada = window.location.pathname.startsWith("/en-ca");
-        const normalized = path.startsWith("/en-ca")
-            ? path
-            : isCanada ? `/en-ca${path}` : path;
+        const normalized = localizeHref(path, window.location.pathname);
         window.history.pushState({}, "", normalized);
     };
 

--- a/src/components/pages/aboutUs/AboutUs.tsx
+++ b/src/components/pages/aboutUs/AboutUs.tsx
@@ -8,6 +8,7 @@ import { trackButtonClick, trackSignupIntent } from "@/src/utils/PostHogTracking
 import { GTagUTM } from "@/src/utils/GTagUTM";
 import { useGeoBypass } from "@/src/utils/useGeoBypass";
 import { FaPlus, FaTimes } from "react-icons/fa";
+import { stripLocalePrefix, localizeHref } from "@/src/utils/locale";
 
 export default function AboutUs() {
   const router = useRouter();
@@ -115,9 +116,8 @@ export default function AboutUs() {
       
         const currentPath = pathname || (typeof window !== 'undefined' ? window.location.pathname : '');
         const normalizedPath = currentPath.split('?')[0];
-        const isAboutUsPage = normalizedPath === '/about-us' || normalizedPath === '/en-ca/about-us';
-        const isAlreadyOnGetMeInterview = normalizedPath === '/get-me-interview' ||
-          normalizedPath === '/en-ca/get-me-interview';
+        const isAboutUsPage = stripLocalePrefix(normalizedPath) === '/about-us';
+        const isAlreadyOnGetMeInterview = stripLocalePrefix(normalizedPath) === '/get-me-interview';
       
         if (isAlreadyOnGetMeInterview) {
           const currentScrollY = typeof window !== 'undefined' ? window.scrollY : 0;
@@ -144,7 +144,7 @@ export default function AboutUs() {
           if (typeof window !== 'undefined') {
             sessionStorage.setItem('preserveScrollPosition', currentScrollY.toString());
           }
-          const targetPath = normalizedPath.startsWith('/en-ca') ? '/en-ca/get-me-interview' : '/get-me-interview';
+          const targetPath = localizeHref('/get-me-interview', normalizedPath);
           if (typeof window !== 'undefined') {
             window.history.pushState({}, '', targetPath);
           }

--- a/src/components/pages/features/Features.tsx
+++ b/src/components/pages/features/Features.tsx
@@ -21,6 +21,7 @@ import { questionsData } from "@/src/data/questionsData"
 import faqStyles from "@/src/components/homePageFAQ/homePageFAQ.module.css"
 import FlashfireLogo from "@/src/components/FlashfireLogo"
 import { trackButtonClick, trackSignupIntent } from "@/src/utils/PostHogTracking"
+import { getLocalePrefix, stripLocalePrefix, localizeHref } from "@/src/utils/locale";
 
 type FeatureItem = {
   title: string
@@ -134,8 +135,7 @@ function Features() {
   const [activeFaq, setActiveFaq] = useState<number | null>(null)
   const [activePersona, setActivePersona] = useState<number | null>(null)
 
-  const isCanadaContext = pathname.startsWith("/en-ca")
-  const prefix = isCanadaContext ? "/en-ca" : ""
+  const prefix = getLocalePrefix(pathname)
 
   const getHref = (href: string) => {
     if (href.startsWith("http")) return href
@@ -172,13 +172,10 @@ function Features() {
 
     const currentPath = pathname || (typeof window !== "undefined" ? window.location.pathname : "")
     const normalizedPath = currentPath.split("?")[0]
-    const isOnFeatures =
-      normalizedPath === "/feature" ||
-      normalizedPath === "/features" ||
-      normalizedPath === "/en-ca/feature" ||
-      normalizedPath === "/en-ca/features"
+    const basePath = stripLocalePrefix(normalizedPath)
+    const isOnFeatures = basePath === "/feature" || basePath === "/features"
     const isAlreadyOnGetMeInterview =
-      normalizedPath === "/get-me-interview" || normalizedPath === "/en-ca/get-me-interview"
+      stripLocalePrefix(normalizedPath) === "/get-me-interview"
 
     if (isAlreadyOnGetMeInterview) {
       const currentScrollY = typeof window !== "undefined" ? window.scrollY : 0
@@ -210,9 +207,7 @@ function Features() {
         sessionStorage.setItem("preserveScrollPosition", window.scrollY.toString())
       }
 
-      const targetPath = normalizedPath.startsWith("/en-ca")
-        ? "/en-ca/get-me-interview"
-        : "/get-me-interview"
+      const targetPath = localizeHref("/get-me-interview", normalizedPath)
       router.replace(targetPath)
       return
     }

--- a/src/components/pages/home/Home.tsx
+++ b/src/components/pages/home/Home.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from "react";
 import { usePathname } from "next/navigation";
+import { isLocaleHome } from "@/src/utils/locale";
 import Footer from "@/src/components/footer/footer";
 import HeroSection from "@/src/components/heroSection/heroSection";
 import HomePageCareerCTA from "@/src/components/homePageCareerCTA/homePageCareerCTA";
@@ -27,7 +28,7 @@ const Home = () => {
 
   useEffect(() => {
     // Scroll to top when navigating to homepage (handles back button and direct navigation)
-    const isHomePage = pathname === "/" || pathname === "/en-ca";
+    const isHomePage = isLocaleHome(pathname);
 
     if (isHomePage) {
       // Use requestAnimationFrame to ensure DOM is ready

--- a/src/components/pages/jobSearch/JobSearch.tsx
+++ b/src/components/pages/jobSearch/JobSearch.tsx
@@ -5,6 +5,7 @@ import { trackButtonClick, trackSignupIntent } from "@/src/utils/PostHogTracking
 import { GTagUTM } from "@/src/utils/GTagUTM";
 import { useGeoBypass } from "@/src/utils/useGeoBypass";
 import { Target, Rocket, Handshake, Trophy, ArrowRight, Check } from "lucide-react";
+import { stripLocalePrefix, localizeHref } from "@/src/utils/locale";
 
 const steps = [
   {
@@ -123,11 +124,9 @@ export default function JobSearch() {
         (typeof window !== "undefined" ? window.location.pathname : "");
       const normalizedPath = currentPath.split("?")[0];
       const isAlreadyOnGetMeInterview =
-        normalizedPath === "/get-me-interview" ||
-        normalizedPath === "/en-ca/get-me-interview";
+        stripLocalePrefix(normalizedPath) === "/get-me-interview";
       const isOnJobSearchPage =
-        normalizedPath === "/job-search" ||
-        normalizedPath === "/en-ca/job-search";
+        stripLocalePrefix(normalizedPath) === "/job-search";
 
       // If already on the route, save scroll position and prevent navigation
       if (isAlreadyOnGetMeInterview) {
@@ -170,9 +169,7 @@ export default function JobSearch() {
           );
         }
 
-        const targetPath = normalizedPath.startsWith("/en-ca")
-          ? "/en-ca/get-me-interview"
-          : "/get-me-interview";
+        const targetPath = localizeHref("/get-me-interview", normalizedPath);
         router.replace(targetPath);
         return;
       }

--- a/src/components/pages/shared/SectionPage.tsx
+++ b/src/components/pages/shared/SectionPage.tsx
@@ -3,7 +3,9 @@
 import { usePathname } from "next/navigation";
 import HomePage from "../home/Home";
 import CanadaHome from "../../countries/ca/Home";
+import UKHome from "../../countries/uk/Home";
 import ScrollToSection from "@/src/utils/ui/scrollToSection";
+import { getLocale } from "@/src/utils/locale";
 
 interface SectionPageProps {
   sectionId: string;
@@ -11,8 +13,9 @@ interface SectionPageProps {
 
 export default function SectionPage({ sectionId }: SectionPageProps) {
   const pathname = usePathname();
-  const isCanadaContext = pathname.startsWith("/en-ca");
-  const HomeComponent = isCanadaContext ? CanadaHome : HomePage;
+  const locale = getLocale(pathname);
+  const HomeComponent =
+    locale === "uk" ? UKHome : locale === "ca" ? CanadaHome : HomePage;
 
   return (
     <>

--- a/src/components/recentJobOpenings/recentJobOpenings.tsx
+++ b/src/components/recentJobOpenings/recentJobOpenings.tsx
@@ -8,6 +8,7 @@ import { GTagUTM } from "@/src/utils/GTagUTM";
 import { FaPlus, FaTimes } from "react-icons/fa";
 import faqStyles from "@/src/components/homePageFAQ/homePageFAQ.module.css";
 import { useEffect, useState } from "react";
+import { localizeHref } from "@/src/utils/locale";
 
 
 export default function RecentJobOpenings() {
@@ -23,10 +24,7 @@ export default function RecentJobOpenings() {
 
     const pushCustomUrl = (path?: string) => {
         if (typeof window === "undefined" || !path) return;
-        const isCanada = window.location.pathname.startsWith("/en-ca");
-        const normalized = path.startsWith("/en-ca")
-            ? path
-            : isCanada ? `/en-ca${path}` : path;
+        const normalized = localizeHref(path, window.location.pathname);
         window.history.pushState({}, "", normalized);
     };
 

--- a/src/data/herosection.ts
+++ b/src/data/herosection.ts
@@ -30,6 +30,36 @@ export const heroSectionData: HeroSectionData = {
   ],
 };
 
+export const heroSectionDataUK: HeroSectionData = {
+  badges: ["HELPING YOU LAND INTERVIEWS FASTER", "50 USERS LANDED JOB"],
+  headlineMain: "Land 15+ Interview Calls with",
+  headlineHighlight: "Flashfire",
+  headlineSuffix: "AI Copilot",
+  description: [
+    "We apply to 1200 UK & EU job applications & track everything while you focus on winning the interview.",
+  ],
+  cta: { label: "Get Started →", href: "/contact-us" },
+  trustText: "Trusted by 1000+ Users",
+  universityHeading:
+    "Trusted by students and graduates from top global universities.",
+  universities: [
+    { name: "University of Oxford", domain: "ox.ac.uk" },
+    { name: "University of Cambridge", domain: "cam.ac.uk" },
+    { name: "Imperial College London", domain: "imperial.ac.uk" },
+    { name: "London School of Economics", domain: "lse.ac.uk" },
+    { name: "University College London", domain: "ucl.ac.uk" },
+    { name: "University of Edinburgh", domain: "ed.ac.uk" },
+    { name: "University of Manchester", domain: "manchester.ac.uk" },
+    { name: "King's College London", domain: "kcl.ac.uk" },
+    { name: "University of Warwick", domain: "warwick.ac.uk" },
+    { name: "University of Bristol", domain: "bristol.ac.uk" },
+    { name: "Delft University of Technology", domain: "tudelft.nl" },
+    { name: "ETH Zurich", domain: "ethz.ch" },
+    { name: "Technical University of Munich", domain: "tum.de" },
+    { name: "Trinity College Dublin", domain: "tcd.ie" },
+  ],
+};
+
 export const heroSectionDataCA: HeroSectionData = {
   badges: ["HELPING YOU LAND INTERVIEWS FASTER", "50 USERS LANDED JOB"],
   headlineMain: "Land 15+ Interview Calls with",

--- a/src/data/pricingData.ts
+++ b/src/data/pricingData.ts
@@ -87,6 +87,91 @@ export const usPricingPlans: PricingPlan[] = [
   },
 ];
 
+/**
+ * UK / EU checkout links.
+ *
+ * TODO(payments): these currently point at the USD Stripe checkouts so the
+ * `/en-uk` pricing page is clickable end to end. Customers reaching them are
+ * charged in USD, not GBP. Replace every value below with the real GBP payment
+ * links before `/en-uk` goes live — this block is the single place to change.
+ */
+export const UK_STRIPE_LINKS = {
+  PRIME: "https://buy.stripe.com/eVq9AV0WY5iGciAegD3AY01",
+  IGNITE: "https://buy.stripe.com/bJe28t7lm12qaasa0n3AY02",
+  PROFESSIONAL: "https://buy.stripe.com/14A6oJcFGfXkgyQfkH3AY03",
+  EXECUTIVE: "https://buy.stripe.com/eVq7sNfRS4eCciAgoL3AY04",
+} as const;
+
+export const ukPricingPlans: PricingPlan[] = [
+  {
+    title: "PRIME",
+    subTitle: "160 Applications",
+    description: "Your starter plan to begin applying",
+    price: "£79",
+    oldPrice: "£189",
+    features: [
+      { title:"No Time Constraint", description: "Until your applications are completed" },
+      { title:"We Find Jobs", description: "We find & apply to jobs for you" },
+      { title:"AI Custom CVs", description: "Tailored CV for every application" },
+      { title:"Expert CV Writing", description: "Our professional team reviews & builds your CV from scratch" },
+    ],
+    addOn: true,
+    highlight: false,
+    paymentLink: UK_STRIPE_LINKS.PRIME,
+  },
+  {
+    title: "IGNITE",
+    subTitle: "250 Applications",
+    description: "For senior professionals & executives",
+    price: "£149",
+    oldPrice: "£229",
+    features: [
+      { title:"No Time Constraint", description: "Until your applications are completed" },
+      { title:"We Find Jobs", description: "We find & apply to jobs for you" },
+      { title:"AI Custom CVs", description: "Tailored CV for every application" },
+      { title:"Expert CV Writing", description: "Our professional team reviews & builds your CV from scratch" },
+    ],
+    addOn: true,
+    highlight: false,
+    paymentLink: UK_STRIPE_LINKS.IGNITE,
+  },
+  {
+    title: "PROFESSIONAL",
+    tag: "ECONOMICAL",
+    subTitle: "500 Applications",
+    description: "Best for mid-level professionals",
+    price: "£299",
+    oldPrice: "£339",
+    inheritsFrom: "IGNITE",
+    features: [
+      { title:"No Time Constraint", description: "Until your applications are completed" },
+      { title:"We Find Jobs", description: "We find & apply to jobs for you" },
+      { title:"LinkedIn Makeover", description: "Let recruiters come to you" },
+      { title:"Interview Prep Material", description: "Resources to help you ace interviews" },
+    ],
+    addOn: true,
+    highlight: false,
+    paymentLink: UK_STRIPE_LINKS.PROFESSIONAL,
+  },
+  {
+    title: "EXECUTIVE",
+    tag: "MOST POPULAR",
+    subTitle: "1200 Applications",
+    description: "For new grads & early professionals",
+    price: "£499",
+    oldPrice: "£529",
+    inheritsFrom: "PROFESSIONAL",
+    features: [
+      { title:"1 Cover Letter", description: "1 cover letter used for all applications" },
+      { title:"Emailing Recruiters", description: "We personally reach out to recruiters for you" },
+      { title:"Portfolio Website", description: "We build a personal site to showcase your projects, skills & achievements" },
+    ],
+    addOn: true,
+    highlight: true,
+    paymentLink: UK_STRIPE_LINKS.EXECUTIVE,
+  },
+];
+
 export const canadaPricingPlans: PricingPlan[] = [
   {
     title: "PRIME",

--- a/src/utils/PostHogTracking.ts
+++ b/src/utils/PostHogTracking.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import posthog from "posthog-js";
 import { apiUrl } from "./apiBase";
+import { getLocale } from "./locale";
 
 // Event naming convention: [action]_[object]_[context]
 // Examples: button_click_hero_cta, form_submit_signup, page_view_home
@@ -45,6 +46,7 @@ export interface PostHogEventProperties {
   country_code?: string;
   country_name?: string;
   is_canada?: boolean;
+  is_uk?: boolean;
   locale?: string;
 
   // Business context
@@ -131,11 +133,14 @@ const getCountryContext = (): Partial<PostHogEventProperties> => {
     return {};
   }
 
-  // Check if user is on Canada page
+  // Work out which country tree the user is on
   const location = safeGetLocation();
-  const isCanada = location.pathname.startsWith("/en-ca");
-  const countryCode = localStorage.getItem("ff_country_code_v1") || (isCanada ? "CA" : "US");
-  
+  const locale = getLocale(location.pathname);
+  const isCanada = locale === "ca";
+  const isUK = locale === "uk";
+  const fallbackCode = isCanada ? "CA" : isUK ? "GB" : "US";
+  const countryCode = localStorage.getItem("ff_country_code_v1") || fallbackCode;
+
   // Map country codes to names
   const countryNames: Record<string, string> = {
     CA: "Canada",
@@ -148,7 +153,8 @@ const getCountryContext = (): Partial<PostHogEventProperties> => {
     country_code: countryCode,
     country_name: countryNames[countryCode] || countryCode,
     is_canada: isCanada,
-    locale: isCanada ? "en-ca" : "en-us",
+    is_uk: isUK,
+    locale: isUK ? "en-uk" : isCanada ? "en-ca" : "en-us",
   };
 };
 

--- a/src/utils/countryDetection.ts
+++ b/src/utils/countryDetection.ts
@@ -1,4 +1,5 @@
 import { apiUrl } from './apiBase';
+import { UK_EU_COUNTRY_CODES } from './locale';
 
 const STORAGE_KEY = 'ff_country_code_v1';
 const CANADA_CODE = 'CA';
@@ -61,20 +62,60 @@ export function detectCountryFallback(): string {
     if (canadaTimezones.some(tz => timezone.includes(tz))) {
       return 'CA';
     }
-    
+
     // Check language for Canada (French Canadian)
     if (language.startsWith('fr-CA')) {
       return 'CA';
     }
-    
+
+    // Check timezone for the UK / EU. Europe/* covers every member state, so
+    // exclude the handful of non-EU Europe/* zones rather than listing all 27.
+    if (timezone.startsWith('Europe/') && !NON_EU_EUROPE_TIMEZONES.has(timezone)) {
+      return 'GB';
+    }
+
+    // Check language for the UK / EU
+    if (UK_EU_LANGUAGE_TAGS.some(tag => language.startsWith(tag))) {
+      return 'GB';
+    }
+
     return 'US';
   } catch {
     return 'US';
   }
 }
 
+/** Europe/* zones that are NOT in the UK or the EU, so they keep the US site. */
+const NON_EU_EUROPE_TIMEZONES = new Set([
+  'Europe/Moscow', 'Europe/Kaliningrad', 'Europe/Samara', 'Europe/Volgograd',
+  'Europe/Saratov', 'Europe/Ulyanovsk', 'Europe/Astrakhan', 'Europe/Kirov',
+  'Europe/Kyiv', 'Europe/Kiev', 'Europe/Uzhgorod', 'Europe/Zaporozhye',
+  'Europe/Minsk', 'Europe/Istanbul', 'Europe/Zurich', 'Europe/Oslo',
+  'Europe/Reykjavik', 'Europe/Vaduz', 'Europe/Belgrade', 'Europe/Sarajevo',
+  'Europe/Skopje', 'Europe/Podgorica', 'Europe/Tirane', 'Europe/Chisinau',
+  'Europe/Gibraltar', 'Europe/Guernsey', 'Europe/Jersey', 'Europe/Isle_of_Man',
+  'Europe/Andorra', 'Europe/Monaco', 'Europe/San_Marino', 'Europe/Vatican',
+  'Europe/Busingen', 'Europe/Mariehamn',
+]);
+
+/** Language tags that imply a UK or EU visitor. */
+const UK_EU_LANGUAGE_TAGS = [
+  'en-GB', 'en-IE',
+  'de-DE', 'de-AT', 'fr-FR', 'fr-BE', 'fr-LU', 'nl-NL', 'nl-BE', 'it-IT',
+  'es-ES', 'pt-PT', 'pl-PL', 'sv-SE', 'da-DK', 'fi-FI', 'el-GR', 'cs-CZ',
+  'sk-SK', 'hu-HU', 'ro-RO', 'bg-BG', 'hr-HR', 'sl-SI', 'et-EE', 'lv-LV',
+  'lt-LT', 'mt-MT', 'ga-IE',
+];
+
 export function shouldRedirectToCanada(pathname: string, countryCode: string | null): boolean {
   if (countryCode === CANADA_CODE && pathname === '/') {
+    return true;
+  }
+  return false;
+}
+
+export function shouldRedirectToUK(pathname: string, countryCode: string | null): boolean {
+  if (countryCode && pathname === '/' && UK_EU_COUNTRY_CODES.has(countryCode)) {
     return true;
   }
   return false;

--- a/src/utils/locale.ts
+++ b/src/utils/locale.ts
@@ -1,0 +1,116 @@
+/**
+ * Locale routing helpers.
+ *
+ * The site serves a default (US) tree at `/` and country trees under a locale
+ * prefix: `/en-ca` for Canada and `/en-uk` for the United Kingdom & the EU.
+ * Everything that needs to build a country-aware link or pick country-specific
+ * content should go through here rather than hard-coding `"/en-ca"` checks, so
+ * adding a locale stays a one-line change.
+ */
+
+export type Locale = "us" | "ca" | "uk";
+
+export const CANADA_PREFIX = "/en-ca";
+export const UK_PREFIX = "/en-uk";
+
+/** Every non-default locale prefix, longest-first so matching is unambiguous. */
+export const LOCALE_PREFIXES = [CANADA_PREFIX, UK_PREFIX] as const;
+
+export type LocalePrefix = (typeof LOCALE_PREFIXES)[number] | "";
+
+/** Country codes that should be served the UK tree: GB + the 27 EU member states. */
+export const UK_EU_COUNTRY_CODES = new Set([
+  "GB", // United Kingdom
+  "AT", // Austria
+  "BE", // Belgium
+  "BG", // Bulgaria
+  "HR", // Croatia
+  "CY", // Cyprus
+  "CZ", // Czechia
+  "DK", // Denmark
+  "EE", // Estonia
+  "FI", // Finland
+  "FR", // France
+  "DE", // Germany
+  "GR", // Greece
+  "HU", // Hungary
+  "IE", // Ireland
+  "IT", // Italy
+  "LV", // Latvia
+  "LT", // Lithuania
+  "LU", // Luxembourg
+  "MT", // Malta
+  "NL", // Netherlands
+  "PL", // Poland
+  "PT", // Portugal
+  "RO", // Romania
+  "SK", // Slovakia
+  "SI", // Slovenia
+  "ES", // Spain
+  "SE", // Sweden
+]);
+
+/**
+ * Returns the locale prefix a path is served under, or `""` for the default
+ * (US) tree. Matches on segment boundaries so `/en-cash` is not treated as
+ * `/en-ca`.
+ */
+export function getLocalePrefix(pathname: string | null | undefined): LocalePrefix {
+  if (!pathname) return "";
+  for (const prefix of LOCALE_PREFIXES) {
+    if (pathname === prefix || pathname.startsWith(`${prefix}/`)) {
+      return prefix;
+    }
+  }
+  return "";
+}
+
+export function getLocale(pathname: string | null | undefined): Locale {
+  const prefix = getLocalePrefix(pathname);
+  if (prefix === CANADA_PREFIX) return "ca";
+  if (prefix === UK_PREFIX) return "uk";
+  return "us";
+}
+
+export function isCanadaPath(pathname: string | null | undefined): boolean {
+  return getLocalePrefix(pathname) === CANADA_PREFIX;
+}
+
+export function isUKPath(pathname: string | null | undefined): boolean {
+  return getLocalePrefix(pathname) === UK_PREFIX;
+}
+
+/** True for any non-default locale tree. */
+export function isLocalizedPath(pathname: string | null | undefined): boolean {
+  return getLocalePrefix(pathname) !== "";
+}
+
+/** Strips a leading locale prefix, so `/en-uk/pricing` becomes `/pricing`. */
+export function stripLocalePrefix(pathname: string | null | undefined): string {
+  if (!pathname) return "/";
+  const prefix = getLocalePrefix(pathname);
+  if (!prefix) return pathname;
+  const rest = pathname.slice(prefix.length);
+  return rest === "" ? "/" : rest;
+}
+
+/**
+ * Rewrites an internal href into the locale tree the user is currently in.
+ * External links and already-prefixed paths are returned untouched.
+ */
+export function localizeHref(href: string, pathname: string | null | undefined): string {
+  if (!href || href.startsWith("http") || href.startsWith("#") || href.startsWith("mailto:") || href.startsWith("tel:")) {
+    return href;
+  }
+  const prefix = getLocalePrefix(pathname);
+  if (!prefix) return href;
+  if (getLocalePrefix(href)) return href;
+  return `${prefix}${href}`;
+}
+
+/** True when the path is the home page of whichever tree it belongs to. */
+export function isLocaleHome(pathname: string | null | undefined): boolean {
+  if (!pathname) return false;
+  const prefix = getLocalePrefix(pathname);
+  return pathname === "/" || pathname === prefix || pathname === `${prefix}/`;
+}


### PR DESCRIPTION
Adds a complete `/en-uk` tree for the UK and EU, mirroring `/en-ca` across all 66 routes and priced in pounds.

## Pricing

| Tier | Was | Now | Save | Applications | £/application |
|---|---|---|---|---|---|
| PRIME | £189 | £79 | 58% | 160 | £0.49 |
| IGNITE | £229 | £149 | 35% | 250 | £0.60 |
| PROFESSIONAL | £339 | £299 | 12% | 500 | £0.60 |
| EXECUTIVE | £529 | £499 | 6% | 1200 | £0.42 |

**Upgrades** are the exact delta between GBP tiers (Prime→Professional £220, Prime→Executive £420, Ignite→Professional £150, Ignite→Executive £350, Professional→Executive £200).

**Add-ons** are new GBP tiers whose per-application rate falls as the bundle grows and is lowest on EXECUTIVE, matching the shape of the existing US and CA ladders:

| Plan | +250 | +500 | +1000 |
|---|---|---|---|
| Prime / Professional | £95 | £160 | £275 |
| Ignite | £105 | £175 | £300 |
| Executive | £88 | £150 | £260 |

## Geo routing

Visitors from **GB and the 27 EU member states** now land on `/en-uk` — IP geolocation first, with `Accept-Language` and timezone as fallback. Canada routing is unchanged.

## Approach

Rather than duplicate the `/en-ca` string checks a second time, this adds `src/utils/locale.ts` and routes every prefix, home-page and path comparison through it. Adding a further locale is now a one-line change.

hreflang is reciprocal across US / CA / UK on all three trees, and the sitemap derives its UK entries from the CA list so the two cannot drift.

## Bugs this surfaced and fixes

- **Currency symbol.** `pricingCard` derived its symbol from the price string and knew only `CA$` and `$`, so GBP plan prices rendered as **`$79`** while the struck-through old price correctly showed `£189`. Now handles `£` and `€`.
- **Shared page components only tested for `/en-ca`.** `app/features/*` and `app/get-me-interview` are re-exported by both locale trees, but their CTA routing hard-coded `/en-ca`, so a UK visitor clicking a feature-page CTA was routed into the US tree and **USD pricing**. Canada worked; UK silently fell through.
- **`AICopilot`** built its prefix with a hard-coded `/en-ca` check, so every link on `/en-uk/AI-copilot` pointed back at the US tree.
- **Missing redirects.** `next.config.ts` had `/en-ca` redirects with no `/en-uk` counterpart, so the UK tree served duplicate content on both `/en-uk/blogs` and `/en-uk/blog` (likewise `how-it-works`, `features/ats-optimizer`).
- **Analytics locale.** `app/en-uk/talk-to-an-expert` reported `locale: "en-ca"`.

## Verification

- Production build passes; TypeScript clean.
- All 66 `/en-uk` and all 66 `/en-ca` routes return 200 or the expected 308; redirect behaviour identical across both trees.
- Geo: GB → `/en-uk`, NL → `/en-uk`, CA → `/en-ca`, US unchanged.
- Currency strictly separated per tree, no cross-leakage: UK shows only GBP, CA only CAD, US only USD. Discounts render 58 / 35 / 12 / 6%.
- ESLint **4 errors better than baseline `main`** (fixed 5 pre-existing issues in the pricing component; `main` already carries 159 errors across 89 files, which this PR does not attempt to clean up).

## ⚠️ Before merging to production

**UK checkout links are still the USD Stripe links.** `UK_STRIPE_LINKS` in `src/data/pricingData.ts` (plus the `ukPaymentUrl` fields and the UK add-on table) intentionally reuse the existing USD checkouts so the page is clickable end to end for review. **Anyone buying via `/en-uk` today is charged in dollars, not pounds.** These must be replaced with real GBP payment links before this goes live — they are marked `TODO(payments)` and grouped so it is a single-place swap.