### PR TITLE
Add /product-demo route with the platform walkthrough video

### DIFF
--- a/app/en-ca/product-demo/page.tsx
+++ b/app/en-ca/product-demo/page.tsx
@@ -1,0 +1,52 @@
+import { Metadata } from "next";
+import Navbar from "@/src/components/navbar/navbar";
+import Footer from "@/src/components/footer/footer";
+import HomePageVideo from "@/src/components/homePageVideo/homePageVideo";
+
+export const metadata: Metadata = {
+  title: "Flashfire Product Demo - See the Platform in Action | Canada",
+  description:
+    "Watch a full walkthrough of the Flashfire platform: how we find roles, tailor your resume for every application, and track everything from one dashboard.",
+  robots: {
+    index: true,
+    follow: true,
+  },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-ca/product-demo",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/product-demo",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/product-demo",
+      "en-GB": "https://www.flashfirejobs.com/en-gb/product-demo",
+      "x-default": "https://www.flashfirejobs.com/product-demo",
+    },
+  },
+  openGraph: {
+    title: "Flashfire Product Demo - See the Platform in Action",
+    description:
+      "A full walkthrough of the Flashfire job search automation platform.",
+    url: "https://www.flashfirejobs.com/en-ca/product-demo",
+    type: "website",
+    images: [
+      {
+        url: "https://www.flashfirejobs.com/images/og-image.png",
+        width: 1200,
+        height: 630,
+        alt: "FLASHFIRE Logo",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    images: ["https://www.flashfirejobs.com/images/og-image.png"],
+  },
+};
+
+export default function ProductDemoPageCA() {
+  return (
+    <>
+      <Navbar />
+      <HomePageVideo />
+      <Footer />
+    </>
+  );
+}

--- a/app/en-gb/product-demo/page.tsx
+++ b/app/en-gb/product-demo/page.tsx
@@ -1,0 +1,52 @@
+import { Metadata } from "next";
+import Navbar from "@/src/components/navbar/navbar";
+import Footer from "@/src/components/footer/footer";
+import HomePageVideo from "@/src/components/homePageVideo/homePageVideo";
+
+export const metadata: Metadata = {
+  title: "Flashfire Product Demo - See the Platform in Action | UK",
+  description:
+    "Watch a full walkthrough of the Flashfire platform: how we find roles, tailor your CV for every application, and track everything from one dashboard.",
+  robots: {
+    index: true,
+    follow: true,
+  },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/en-gb/product-demo",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/product-demo",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/product-demo",
+      "en-GB": "https://www.flashfirejobs.com/en-gb/product-demo",
+      "x-default": "https://www.flashfirejobs.com/product-demo",
+    },
+  },
+  openGraph: {
+    title: "Flashfire Product Demo - See the Platform in Action",
+    description:
+      "A full walkthrough of the Flashfire job search automation platform.",
+    url: "https://www.flashfirejobs.com/en-gb/product-demo",
+    type: "website",
+    images: [
+      {
+        url: "https://www.flashfirejobs.com/images/og-image.png",
+        width: 1200,
+        height: 630,
+        alt: "FLASHFIRE Logo",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    images: ["https://www.flashfirejobs.com/images/og-image.png"],
+  },
+};
+
+export default function ProductDemoPageUK() {
+  return (
+    <>
+      <Navbar />
+      <HomePageVideo />
+      <Footer />
+    </>
+  );
+}

--- a/app/en-us/product-demo/page.tsx
+++ b/app/en-us/product-demo/page.tsx
@@ -1,0 +1,1 @@
+export { default, metadata } from "@/app/product-demo/page";

--- a/app/product-demo/page.tsx
+++ b/app/product-demo/page.tsx
@@ -1,0 +1,52 @@
+import { Metadata } from "next";
+import Navbar from "@/src/components/navbar/navbar";
+import Footer from "@/src/components/footer/footer";
+import HomePageVideo from "@/src/components/homePageVideo/homePageVideo";
+
+export const metadata: Metadata = {
+  title: "Flashfire Product Demo - See the Platform in Action",
+  description:
+    "Watch a full walkthrough of the Flashfire platform: how we find roles, tailor your resume for every application, and track everything from one dashboard.",
+  robots: {
+    index: true,
+    follow: true,
+  },
+  alternates: {
+    canonical: "https://www.flashfirejobs.com/product-demo",
+    languages: {
+      "en-US": "https://www.flashfirejobs.com/product-demo",
+      "en-CA": "https://www.flashfirejobs.com/en-ca/product-demo",
+      "en-GB": "https://www.flashfirejobs.com/en-gb/product-demo",
+      "x-default": "https://www.flashfirejobs.com/product-demo",
+    },
+  },
+  openGraph: {
+    title: "Flashfire Product Demo - See the Platform in Action",
+    description:
+      "A full walkthrough of the Flashfire job search automation platform.",
+    url: "https://www.flashfirejobs.com/product-demo",
+    type: "website",
+    images: [
+      {
+        url: "https://www.flashfirejobs.com/images/og-image.png",
+        width: 1200,
+        height: 630,
+        alt: "FLASHFIRE Logo",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    images: ["https://www.flashfirejobs.com/images/og-image.png"],
+  },
+};
+
+export default function ProductDemoPage() {
+  return (
+    <>
+      <Navbar />
+      <HomePageVideo />
+      <Footer />
+    </>
+  );
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -111,6 +111,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: 'yearly' as const,
       priority: 0.3,
     },
+    {
+      url: `${baseUrl}/product-demo`,
+      lastModified: new Date('2026-08-13'),
+      changeFrequency: 'monthly' as const,
+      priority: 0.8,
+    },
   ]
 
   const canadaRoutes: MetadataRoute.Sitemap = [
@@ -138,6 +144,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { url: `${baseUrl}/en-ca/image-testimonials`, lastModified: new Date('2025-11-01'), changeFrequency: 'monthly' as const, priority: 0.5 },
     { url: `${baseUrl}/en-ca/see-flashfire-in-action`, lastModified: new Date('2025-11-01'), changeFrequency: 'monthly' as const, priority: 0.5 },
     { url: `${baseUrl}/en-ca/talk-to-an-expert`, lastModified: new Date('2025-11-01'), changeFrequency: 'monthly' as const, priority: 0.5 },
+    { url: `${baseUrl}/en-ca/product-demo`, lastModified: new Date('2026-08-13'), changeFrequency: 'monthly' as const, priority: 0.8 },
   ]
 
   // The UK tree mirrors the Canada tree exactly, so derive it rather than


### PR DESCRIPTION
Adds a dedicated page at **flashfirejobs.com/product-demo** carrying the same dashboard walkthrough video already used on the home page — so it can be linked directly from ads and outreach instead of pointing people at the home page and hoping they scroll to it.

## What's on the page

Exactly three things, as specified:

1. **Navbar** — which already includes the anniversary promo banner above it
2. **The video** (`/videos/Untitled design.mp4`)
3. **Footer**

No hero copy, no extra CTA sections.

## Notes

`HomePageVideo` is reused **as-is** rather than forked, so the orange corner-bracket treatment and the video source stay in one place. No existing component was modified. Because the video sits near the top of this page, its scroll-driven tilt resolves to 0° on load, so it renders flat and immediately playable — matching the reference.

Mirrored into the `/en-us`, `/en-ca` and `/en-gb` trees following each tree's existing convention (`en-us` re-exports; `en-ca`/`en-gb` carry their own canonical + localized copy, "resume" → "CV" for GB). hreflang is reciprocal across all four.

Added to the sitemap at priority 0.8; the `/en-gb` entry derives from the Canada list automatically.

## Verification

- Build passes, TypeScript clean.
- All four routes prerender as **static** and return 200: `/product-demo`, `/en-us/product-demo`, `/en-ca/product-demo`, `/en-gb/product-demo`.
- Video asset serves with range support (206, `video/mp4`); poster resolves.
- Rendered HTML confirmed to contain the promo banner, all nav links, the Get Started CTA, the video with the correct source, and all seven footer columns.

## One thing to confirm

The page is set to **`index: true`** — a public, indexable marketing page. If this is meant only for paid campaigns and shouldn't appear in search, say so and I'll flip it to `noindex` and drop the sitemap entries.